### PR TITLE
Fix npm run compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typedoc": "typedoc --out docs $(pwd)/src --target es6 --mode file --tsconfig ./tsconfig.json --excludePrivate --excludeProtected --exclude **/*.spec.ts",
     "check": "gts check",
     "clean": "gts clean",
-    "compile": "tsc -p .",
+    "compile": "mkdir -p build/src; cp src/*.js build/src; tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
     "pretest": "npm run compile",


### PR DESCRIPTION
This patch fixes npm run compile to correctly copy the original js files to the build directory.