### PR TITLE
Remove git modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/jsonTests"]
-	path = test/jsonTests
-	url = https://github.com/ethereum/tests


### PR DESCRIPTION
It seems that a submodule to the official test repository used to
be used for tests.

This PR removes that submodule, since it seems to be undocumented,
and the test files are (for now) in the source tree.