### PR TITLE
Fix verifyWitness embedded extension-branch

### DIFF
--- a/src/proof.spec.ts
+++ b/src/proof.spec.ts
@@ -78,4 +78,20 @@ describe(
         VerifyWitness(tree.root, Buffer.from('key2'), w2);
         VerifyWitness(tree.root, Buffer.from('key3'), w3);
       });
+
+
+      it('should create a merkle proof with an extension and embedded branch',
+         async () => {
+           await tree.put(Buffer.from('a'), Buffer.from('a'));
+           await tree.put(Buffer.from('b'), Buffer.from('b'));
+           await tree.put(Buffer.from('c'), Buffer.from('c'));
+
+           const w1 = await tree.get(Buffer.from('a'));
+           const w2 = await tree.get(Buffer.from('b'));
+           const w3 = await tree.get(Buffer.from('c'));
+
+           VerifyWitness(tree.root, Buffer.from('a'), w1);
+           VerifyWitness(tree.root, Buffer.from('b'), w2);
+           VerifyWitness(tree.root, Buffer.from('c'), w3);
+         });
     });


### PR DESCRIPTION
It seems that verify witness fails when there is an embedded extension branch. This causes an "Unexpected end of proof error".

This can occur if there are small values and keys.

A simple tree that causes this error can be created by executing:

put(a, a)
put(b, b)
put(c, c)

This PR fixes `VerifyWitness` to handle this case.

This seems to be a bug inherited from the upstream project and should be fixed there as well.
A PR has been opened under  ethereumjs/merkle-patricia-tree#51