### PR TITLE
Use own nodes, remove original tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -503,10 +503,12 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "anymatch": {
       "version": "2.0.0",
@@ -701,10 +703,35 @@
         "js-tokens": "^3.0.2"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -1315,16 +1342,13 @@
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
@@ -1489,7 +1513,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
       "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.1"
       }
@@ -1497,8 +1520,7 @@
     "color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
-      "dev": true
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
     "colors": {
       "version": "1.3.1",
@@ -2356,8 +2378,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint-scope": {
       "version": "4.0.0",
@@ -3714,8 +3735,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -7701,10 +7721,12 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
     },
     "tapable": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "async": "^1.4.2",
-    "ethereumjs-util": "^5.0.0",
+    "keccak": "^1.4.0",
     "level-ws": "0.0.0",
     "levelup": "^1.2.1",
     "memdown": "^1.0.0",
@@ -59,6 +59,7 @@
     "benchmark": "^2.1.4",
     "chai": "^4.1.2",
     "coveralls": "^3.0.2",
+    "ethereumjs-util": "^5.0.0",
     "gts": "^0.5.4",
     "istanbul": "^0.4.1",
     "karma": "^3.0.0",


### PR DESCRIPTION
This PR removes the original tree and fully moves to an in-memory tree using in-memory node objects. It currently passes all tests.

Performance is much better in some benchmarks, but in benchmarks where the root hash is calculated often, performance is significantly worse because no memoization is currently performed, and all nodes are rehashed (and re-serialized) each time.

Performance under this PR:
```
no-op: 203302±1.37% ops/s 0.005±0.0003 ms/op (61 runs)
put (empty tree): 148007±2.29% ops/s 0.007±0.0007 ms/op (79 runs)
get (empty tree): 123978±1.08% ops/s 0.008±0.0004 ms/op (82 runs)
generate 1k-1k-32-ran: 7.22±2.78% ops/s 138.479±12.2518 ms/op (39 runs)
generate 1k-1k-32-mir: 6.83±1.77% ops/s 146.483±8.0458 ms/op (37 runs)
generate 1k-9-32-ran: 0.17±0.70% ops/s 5745.930±32.2490 ms/op (5 runs)
generate 1k-5-32-ran: 0.10±0.77% ops/s 9761.893±60.2392 ms/op (5 runs)
generate 1k-3-32-ran: 0.06±3.44% ops/s 17253.144±477.5414 ms/op (5 runs)
```

Under the original tree:
```
put (empty tree): 19247±3.74% ops/s 0.052±0.0088 ms/op (79 runs)
get (empty tree): 115079±1.39% ops/s 0.009±0.0005 ms/op (78 runs)
generate 1k-1k-32-ran: 3.99±5.56% ops/s 250.683±33.0097 ms/op (24 runs)
generate 1k-1k-32-mir: 4.41±3.37% ops/s 226.868±18.8978 ms/op (26 runs)
generate 1k-9-32-ran: 4.59±4.10% ops/s 217.744±22.5524 ms/op (27 runs)
generate 1k-5-32-ran: 4.62±3.40% ops/s 216.660±18.6436 ms/op (27 runs)
generate 1k-3-32-ran: 4.48±3.60% ops/s 223.153±19.8981 ms/op (26 runs)
```

This PR makes some potentially breaking changes by removing interfaces to the original tree.