### PR TITLE
Add back official branch-value-update test

### DIFF
--- a/test/trietest.json
+++ b/test/trietest.json
@@ -93,5 +93,13 @@
       [ "key3","1234567890123456789012345678901"]
     ],
     "root": "0xcb65032e2f76c48b82b5c24b3db8f670ce73982869d38cd39a624f23d62a9e89"
+  },
+  "branch-value-update": {
+    "in": [
+      [ "abc", "123" ],
+      [ "abcd", "abcd" ],
+      [ "abc", "abc" ]
+    ],
+    "root": "0x7a320748f780ad9ad5b0837302075ce0eeba6c26e3d8562c67ccc0f1b273298a"
   }
 }


### PR DESCRIPTION
Since we're now passing the offical branch-value-update test, this PR adds it back in.