### PR TITLE
Switch to sync API, basic memoization

### DIFF
--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -61,21 +61,21 @@ const addAsyncTest = <T>(
  *
  *  @returns            A {MerklePatriciaTree} initialized to the given inputs.
  */
-const generateStandardTree = async (
-    rounds: number, eraSize: number, symmetric: boolean,
-    seed: Buffer = Buffer.alloc(32, 0)) => {
-  const tree = new MerklePatriciaTree();
-  let batchOps: BatchPut[] = [];
-  for (let i = 1; i <= rounds; i++) {
-    seed = ethUtil.sha3(seed);
-    batchOps.push({key: seed, val: symmetric ? seed : ethUtil.sha3(seed)});
-    if (i % eraSize === 0) {
-      seed = await tree.batch(batchOps);
-      batchOps = [];
-    }
-  }
-  return tree;
-};
+const generateStandardTree =
+    (rounds: number, eraSize: number, symmetric: boolean,
+     seed: Buffer = Buffer.alloc(32, 0)) => {
+      const tree = new MerklePatriciaTree();
+      let batchOps: BatchPut[] = [];
+      for (let i = 1; i <= rounds; i++) {
+        seed = ethUtil.sha3(seed);
+        batchOps.push({key: seed, val: symmetric ? seed : ethUtil.sha3(seed)});
+        if (i % eraSize === 0) {
+          seed = tree.batch(batchOps);
+          batchOps = [];
+        }
+      }
+      return tree;
+    };
 
 //#region Simple tests
 
@@ -84,39 +84,39 @@ addAsyncTest('no-op', async () => {}, () => null);
 
 // Tests the performance of inserting into an empty tree.
 addAsyncTest('put (empty tree)', async (tree) => {
-  await tree.put(Buffer.from('a'), Buffer.from('b'));
+  tree.put(Buffer.from('a'), Buffer.from('b'));
 }, () => new MerklePatriciaTree());
 
 // Tests the performance of getting from an empty tree.
 addAsyncTest('get (empty tree)', async (tree) => {
-  await tree.get(Buffer.from('a'));
+  tree.get(Buffer.from('a'));
 }, () => new MerklePatriciaTree());
 
 //#endregion
 
 //#region Tree generation tests
 addAsyncTest('generate 1k-10k-32-ran', async () => {
-  await generateStandardTree(1000, 10000, true);
+  generateStandardTree(1000, 10000, true);
 });
 
 addAsyncTest('generate 1k-1k-32-ran', async () => {
-  await generateStandardTree(1000, 1000, true);
+  generateStandardTree(1000, 1000, true);
 });
 
 addAsyncTest('generate 1k-1k-32-mir', async () => {
-  await generateStandardTree(1000, 1000, false);
+  generateStandardTree(1000, 1000, false);
 });
 
 addAsyncTest('generate 1k-9-32-ran', async () => {
-  await generateStandardTree(1000, 9, true);
+  generateStandardTree(1000, 9, true);
 });
 
 addAsyncTest('generate 1k-5-32-ran', async () => {
-  await generateStandardTree(1000, 5, true);
+  generateStandardTree(1000, 5, true);
 });
 
 addAsyncTest('generate 1k-3-32-ran', async () => {
-  await generateStandardTree(1000, 3, true);
+  generateStandardTree(1000, 3, true);
 });
 //#endregion
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -21,52 +21,52 @@ describe('Try original simple-save-retrieve', () => {
   const two = Buffer.from('two');
 
   it('should save a value', async () => {
-    await tree.put(Buffer.from('test'), one);
+    tree.put(Buffer.from('test'), one);
   });
 
   it('should get a value', async () => {
-    const val = await tree.get(Buffer.from('test'));
+    const val = tree.get(Buffer.from('test'));
     should.exist(val.value);
     val.value!.should.deep.equal(one);
   });
 
   it('should update a value', async () => {
-    await tree.put(Buffer.from('test'), two);
-    const val = await tree.get(Buffer.from('test'));
+    tree.put(Buffer.from('test'), two);
+    const val = tree.get(Buffer.from('test'));
     should.exist(val.value);
     val.value!.should.deep.equal(two);
   });
 
   it('should delete value', async () => {
-    await tree.del(Buffer.from('test'));
-    should.not.exist((await tree.get(Buffer.from('test'))).value);
+    tree.del(Buffer.from('test'));
+    should.not.exist((tree.get(Buffer.from('test'))).value);
   });
 
   it('should recreate value', async () => {
-    await tree.put(Buffer.from('test'), one);
+    tree.put(Buffer.from('test'), one);
   });
 
   it('should get updated value', async () => {
-    const val = await tree.get(Buffer.from('test'));
+    const val = tree.get(Buffer.from('test'));
     should.exist(val.value);
     val.value!.should.deep.equal(one);
   });
 
   it('should create a branch', async () => {
-    await tree.put(Buffer.from('doge'), Buffer.from('coin'));
+    tree.put(Buffer.from('doge'), Buffer.from('coin'));
     tree.root.toString('hex').should.equal(
         'de8a34a8c1d558682eae1528b47523a483dd8685d6db14b291451a66066bf0fc');
   });
 
   it('should get a value in a branch', async () => {
-    const val = await tree.get(Buffer.from('doge'));
+    const val = tree.get(Buffer.from('doge'));
     should.exist(val.value);
     val.value!.should.deep.equal(Buffer.from('coin'));
   });
 
   it('should delete from a branch', async () => {
-    await tree.del(Buffer.from('doge'));
-    should.not.exist((await tree.get(Buffer.from('doge'))).value);
+    tree.del(Buffer.from('doge'));
+    should.not.exist((tree.get(Buffer.from('doge'))).value);
   });
 });
 
@@ -79,20 +79,20 @@ describe('Try original storing larger values', () => {
       'b173e2db29e79c78963cff5196f8a983fbe0171388972106b114ef7f5c24dfa3';
 
   it('should store a larger string', async () => {
-    await tree.put(Buffer.from('done'), Buffer.from(longString));
-    await tree.put(Buffer.from('doge'), Buffer.from('coin'));
+    tree.put(Buffer.from('done'), Buffer.from(longString));
+    tree.put(Buffer.from('doge'), Buffer.from('coin'));
     tree.root.toString('hex').should.equal(longStringRoot);
   });
 
   it('should retrieve longer values', async () => {
-    const val = await tree.get(Buffer.from('done'));
+    const val = tree.get(Buffer.from('done'));
     should.exist(val.value);
     val.value!.should.deep.equal(Buffer.from(longString));
   });
 
   it('should be able to update older values', async () => {
-    await tree.put(Buffer.from('done'), Buffer.from('test'));
-    const val = await tree.get(Buffer.from('done'));
+    tree.put(Buffer.from('done'), Buffer.from('test'));
+    const val = tree.get(Buffer.from('done'));
     should.exist(val.value);
     val.value!.should.deep.equal(Buffer.from('test'));
   });
@@ -103,17 +103,17 @@ describe('Try original extensions and branches', () => {
   const tree: MerklePatriciaTree = new MerklePatriciaTree();
 
   it('should store a value', async () => {
-    await tree.put(Buffer.from('doge'), Buffer.from('coin'));
+    tree.put(Buffer.from('doge'), Buffer.from('coin'));
   });
 
   it('should create an extension', async () => {
-    await tree.put(Buffer.from('do'), Buffer.from('verb'));
+    tree.put(Buffer.from('do'), Buffer.from('verb'));
     tree.root.toString('hex').should.equal(
         'f803dfcb7e8f1afd45e88eedb4699a7138d6c07b71243d9ae9bff720c99925f9');
   });
 
   it('should store a new value in the extension', async () => {
-    await tree.put(Buffer.from('done'), Buffer.from('finished'));
+    tree.put(Buffer.from('done'), Buffer.from('finished'));
     tree.root.toString('hex').should.equal(
         '409cff4d820b394ed3fb1cd4497bdd19ffa68d30ae34157337a7043c94a3e8cb');
   });
@@ -123,17 +123,17 @@ describe('Try original extensions and branches - reverse', () => {
   const tree: MerklePatriciaTree = new MerklePatriciaTree();
 
   it('should create an extension', async () => {
-    await tree.put(Buffer.from('do'), Buffer.from('verb'));
+    tree.put(Buffer.from('do'), Buffer.from('verb'));
   });
 
   it('should store another value', async () => {
-    await tree.put(Buffer.from('doge'), Buffer.from('coin'));
+    tree.put(Buffer.from('doge'), Buffer.from('coin'));
     tree.root.toString('hex').should.equal(
         'f803dfcb7e8f1afd45e88eedb4699a7138d6c07b71243d9ae9bff720c99925f9');
   });
 
   it('should store another value in the extension', async () => {
-    await tree.put(Buffer.from('done'), Buffer.from('finished'));
+    tree.put(Buffer.from('done'), Buffer.from('finished'));
     tree.root.toString('hex').should.equal(
         '409cff4d820b394ed3fb1cd4497bdd19ffa68d30ae34157337a7043c94a3e8cb');
   });
@@ -152,9 +152,8 @@ describe('Try original deletions tests', () => {
         Buffer.from([12, 22, 22]), Buffer.from('create the first branch'));
     const a3 = tree.put(
         Buffer.from([12, 33, 44]), Buffer.from('create the last branch'));
-    await Promise.all([a1, a2, a3]);
-    await tree.del(Buffer.from([12, 22, 22]));
-    const val = await tree.get(Buffer.from([12, 22, 22]));
+    tree.del(Buffer.from([12, 22, 22]));
+    const val = tree.get(Buffer.from([12, 22, 22]));
     should.not.exist(val.value);
   });
 
@@ -167,35 +166,30 @@ describe('Try original deletions tests', () => {
     const a4 = tree.put(
         Buffer.from([12, 33, 44]), Buffer.from('create the last branch'));
 
-    await Promise.all([a1, a2, a3, a4]);
-    await tree.del(Buffer.from([12, 22, 22]));
-    const val = await tree.get(Buffer.from([12, 22, 22]));
+    tree.del(Buffer.from([12, 22, 22]));
+    const val = tree.get(Buffer.from([12, 22, 22]));
     should.not.exist(val.value);
   });
 
   it('should delete from a extension->branch-extension', async () => {
-    await tree.put(Buffer.from([11, 11, 11]), Buffer.from('first'));
-    await tree.put(
-        Buffer.from([12, 22, 22]), Buffer.from('create the first branch'));
-    await tree.put(
+    tree.put(Buffer.from([11, 11, 11]), Buffer.from('first'));
+    tree.put(Buffer.from([12, 22, 22]), Buffer.from('create the first branch'));
+    tree.put(
         Buffer.from([12, 33, 33]), Buffer.from('create the middle branch'));
-    await tree.put(
-        Buffer.from([12, 33, 44]), Buffer.from('create the last branch'));
-    await tree.del(Buffer.from([11, 11, 11]));
-    const val = await tree.get(Buffer.from([11, 11, 11]));
+    tree.put(Buffer.from([12, 33, 44]), Buffer.from('create the last branch'));
+    tree.del(Buffer.from([11, 11, 11]));
+    const val = tree.get(Buffer.from([11, 11, 11]));
     should.not.exist(val.value);
   });
 
   it('should delete from a extension->branch-branch', async () => {
-    await tree.put(Buffer.from([11, 11, 11]), Buffer.from('first'));
-    await tree.put(
-        Buffer.from([12, 22, 22]), Buffer.from('create the first branch'));
-    await tree.put(
+    tree.put(Buffer.from([11, 11, 11]), Buffer.from('first'));
+    tree.put(Buffer.from([12, 22, 22]), Buffer.from('create the first branch'));
+    tree.put(
         Buffer.from([12, 33, 33]), Buffer.from('create the middle branch'));
-    await tree.put(
-        Buffer.from([12, 34, 44]), Buffer.from('create the last branch'));
-    await tree.del(Buffer.from([11, 11, 11]));
-    const val = await tree.get(Buffer.from([11, 11, 11]));
+    tree.put(Buffer.from([12, 34, 44]), Buffer.from('create the last branch'));
+    tree.del(Buffer.from([11, 11, 11]));
+    const val = tree.get(Buffer.from([11, 11, 11]));
     should.not.exist(val.value);
   });
 });
@@ -224,17 +218,17 @@ describe('Creating the ethereum genesis block', () => {
   const tree: MerklePatriciaTree = new MerklePatriciaTree();
 
   it('should match the original genesis root', async () => {
-    await tree.put(g, rlpAccount);
-    await tree.put(j, rlpAccount);
-    await tree.put(v, rlpAccount);
-    await tree.put(a, rlpAccount);
+    tree.put(g, rlpAccount);
+    tree.put(j, rlpAccount);
+    tree.put(v, rlpAccount);
+    tree.put(a, rlpAccount);
     tree.root.toString('hex').should.equal(genesisStateRoot);
   });
 
   const treeBatch: MerklePatriciaTree = new MerklePatriciaTree();
 
   it('should match the original genesis root in batch mode', async () => {
-    const root = await treeBatch.batch([
+    const root = treeBatch.batch([
       {key: g, val: rlpAccount},
       {key: j, val: rlpAccount},
       {key: v, val: rlpAccount},
@@ -247,15 +241,15 @@ describe('Creating the ethereum genesis block', () => {
 describe('Try batch operations', () => {
   it('put a simple batch', async () => {
     const tree = new MerklePatriciaTree();
-    const root = await tree.batch([
+    const root = tree.batch([
       {key: Buffer.from('a'), val: Buffer.from('a')},
       {key: Buffer.from('b'), val: Buffer.from('b')},
       {key: Buffer.from('c'), val: Buffer.from('c')}
     ]);
 
-    const w1 = await tree.get(Buffer.from('a'));
-    const w2 = await tree.get(Buffer.from('b'));
-    const w3 = await tree.get(Buffer.from('c'));
+    const w1 = tree.get(Buffer.from('a'));
+    const w2 = tree.get(Buffer.from('b'));
+    const w3 = tree.get(Buffer.from('c'));
 
     VerifyWitness(root, Buffer.from('a'), w1);
     VerifyWitness(root, Buffer.from('b'), w2);
@@ -264,9 +258,9 @@ describe('Try batch operations', () => {
 
   it('put and del a simple batch', async () => {
     const tree = new MerklePatriciaTree();
-    await tree.put(Buffer.from('d'), Buffer.from('d'));
+    tree.put(Buffer.from('d'), Buffer.from('d'));
 
-    const root = await tree.batch(
+    const root = tree.batch(
         [
           {key: Buffer.from('a'), val: Buffer.from('a')},
           {key: Buffer.from('b'), val: Buffer.from('b')},
@@ -274,21 +268,21 @@ describe('Try batch operations', () => {
         ],
         [Buffer.from('d')]);
 
-    const w1 = await tree.get(Buffer.from('a'));
-    const w2 = await tree.get(Buffer.from('b'));
-    const w3 = await tree.get(Buffer.from('c'));
+    const w1 = tree.get(Buffer.from('a'));
+    const w2 = tree.get(Buffer.from('b'));
+    const w3 = tree.get(Buffer.from('c'));
 
     VerifyWitness(root, Buffer.from('a'), w1);
     VerifyWitness(root, Buffer.from('b'), w2);
     VerifyWitness(root, Buffer.from('c'), w3);
 
-    const w4 = await tree.get(Buffer.from('d'));
+    const w4 = tree.get(Buffer.from('d'));
     should.not.exist(w4.value);
   });
 
   it('put and del a simple batch with overlap', async () => {
     const tree = new MerklePatriciaTree();
-    const root = await tree.batch(
+    const root = tree.batch(
         [
           {key: Buffer.from('a'), val: Buffer.from('a')},
           {key: Buffer.from('b'), val: Buffer.from('b')},
@@ -296,9 +290,9 @@ describe('Try batch operations', () => {
         ],
         [Buffer.from('c')]);
 
-    const w1 = await tree.get(Buffer.from('a'));
-    const w2 = await tree.get(Buffer.from('b'));
-    const w3 = await tree.get(Buffer.from('c'));
+    const w1 = tree.get(Buffer.from('a'));
+    const w2 = tree.get(Buffer.from('b'));
+    const w3 = tree.get(Buffer.from('c'));
 
     VerifyWitness(root, Buffer.from('a'), w1);
     VerifyWitness(root, Buffer.from('b'), w2);

--- a/src/official.spec.ts
+++ b/src/official.spec.ts
@@ -46,24 +46,8 @@ describe('Run official tests', () => {
 
     it(`should pass official test ${testName}`, async () => {
       for (const pair of testData.in) {
-        await tree.put(testDataToBuffer(pair[0]), testDataToBuffer(pair[1]));
+        tree.put(testDataToBuffer(pair[0]), testDataToBuffer(pair[1]));
       }
-      `0x${tree.root.toString('hex')}`.should.equal(testData.root);
-    });
-  }
-});
-
-describe('Run official tests async', () => {
-  for (const [testName, testData] of Object.entries(testJson)) {
-    const tree = new MerklePatriciaTree();
-
-    it(`should pass official test ${testName}`, async () => {
-      const promises = [];
-      for (const pair of testData.in) {
-        promises.push(
-            tree.put(testDataToBuffer(pair[0]), testDataToBuffer(pair[1])));
-      }
-      await Promise.all(promises);
       `0x${tree.root.toString('hex')}`.should.equal(testData.root);
     });
   }
@@ -75,25 +59,8 @@ describe('Run official tests (secure)', () => {
 
     it(`should pass official test ${testName}`, async () => {
       for (const pair of testData.in) {
-        await tree.put(
-            secureTestDataToBuffer(pair[0]), testDataToBuffer(pair[1]));
+        tree.put(secureTestDataToBuffer(pair[0]), testDataToBuffer(pair[1]));
       }
-      `0x${tree.root.toString('hex')}`.should.equal(testData.root);
-    });
-  }
-});
-
-describe('Run official tests (secure) async', () => {
-  for (const [testName, testData] of Object.entries(testJsonSecure)) {
-    const tree = new MerklePatriciaTree();
-
-    it(`should pass official test ${testName}`, async () => {
-      const promises = [];
-      for (const pair of testData.in) {
-        promises.push(tree.put(
-            secureTestDataToBuffer(pair[0]), testDataToBuffer(pair[1])));
-      }
-      await Promise.all(promises);
       `0x${tree.root.toString('hex')}`.should.equal(testData.root);
     });
   }

--- a/src/proof.spec.ts
+++ b/src/proof.spec.ts
@@ -1,6 +1,5 @@
 import 'mocha';
 
-import {AsyncResource} from 'async_hooks';
 import * as chai from 'chai';
 import * as path from 'path';
 import {RlpEncode, RlpList} from 'rlp-stream';
@@ -25,15 +24,15 @@ describe(
       });
 
       it('should create a merkle proof and verify it', async () => {
-        await tree.put(
+        tree.put(
             Buffer.from('key1aa'),
             Buffer.from('0123456789012345678901234567890123456789xx'));
-        await tree.put(Buffer.from('key2bb'), Buffer.from('aval2'));
-        await tree.put(Buffer.from('key3cc'), Buffer.from('aval3'));
+        tree.put(Buffer.from('key2bb'), Buffer.from('aval2'));
+        tree.put(Buffer.from('key3cc'), Buffer.from('aval3'));
 
-        const w1 = await tree.get(Buffer.from('key1aa'));
-        const w2 = await tree.get(Buffer.from('key2bb'));
-        const w3 = await tree.get(Buffer.from('key3cc'));
+        const w1 = tree.get(Buffer.from('key1aa'));
+        const w2 = tree.get(Buffer.from('key2bb'));
+        const w3 = tree.get(Buffer.from('key3cc'));
 
         VerifyWitness(tree.root, Buffer.from('key1aa'), w1);
         VerifyWitness(tree.root, Buffer.from('key2bb'), w2);
@@ -42,37 +41,37 @@ describe(
 
       it('should create a merkle proof and verify it with a single long key',
          async () => {
-           await tree.put(
+           tree.put(
                Buffer.from('key1aa'),
                Buffer.from('0123456789012345678901234567890123456789xx'));
-           const w1 = await tree.get(Buffer.from('key1aa'));
+           const w1 = tree.get(Buffer.from('key1aa'));
            VerifyWitness(tree.root, Buffer.from('key1aa'), w1);
          });
 
       it('should create a merkle proof and verify it with a single short key',
          async () => {
-           await tree.put(Buffer.from('key1aa'), Buffer.from('01234'));
-           const w1 = await tree.get(Buffer.from('key1aa'));
+           tree.put(Buffer.from('key1aa'), Buffer.from('01234'));
+           const w1 = tree.get(Buffer.from('key1aa'));
            VerifyWitness(tree.root, Buffer.from('key1aa'), w1);
          });
 
       it('should create a merkle proof with keys in the middle', async () => {
-        await tree.put(
+        tree.put(
             Buffer.from('key1aa'),
             Buffer.from('0123456789012345678901234567890123456789xxx'));
-        await tree.put(
+        tree.put(
             Buffer.from('key1'),
             Buffer.from('0123456789012345678901234567890123456789Very_Long'));
-        await tree.put(Buffer.from('key2bb'), Buffer.from('aval3'));
-        await tree.put(Buffer.from('key2'), Buffer.from('short'));
-        await tree.put(Buffer.from('key3cc'), Buffer.from('aval3'));
-        await tree.put(
+        tree.put(Buffer.from('key2bb'), Buffer.from('aval3'));
+        tree.put(Buffer.from('key2'), Buffer.from('short'));
+        tree.put(Buffer.from('key3cc'), Buffer.from('aval3'));
+        tree.put(
             Buffer.from('key3'),
             Buffer.from('1234567890123456789012345678901'));
 
-        const w1 = await tree.get(Buffer.from('key1'));
-        const w2 = await tree.get(Buffer.from('key2'));
-        const w3 = await tree.get(Buffer.from('key3'));
+        const w1 = tree.get(Buffer.from('key1'));
+        const w2 = tree.get(Buffer.from('key2'));
+        const w3 = tree.get(Buffer.from('key3'));
 
         VerifyWitness(tree.root, Buffer.from('key1'), w1);
         VerifyWitness(tree.root, Buffer.from('key2'), w2);
@@ -82,13 +81,13 @@ describe(
 
       it('should create a merkle proof with an extension and embedded branch',
          async () => {
-           await tree.put(Buffer.from('a'), Buffer.from('a'));
-           await tree.put(Buffer.from('b'), Buffer.from('b'));
-           await tree.put(Buffer.from('c'), Buffer.from('c'));
+           tree.put(Buffer.from('a'), Buffer.from('a'));
+           tree.put(Buffer.from('b'), Buffer.from('b'));
+           tree.put(Buffer.from('c'), Buffer.from('c'));
 
-           const w1 = await tree.get(Buffer.from('a'));
-           const w2 = await tree.get(Buffer.from('b'));
-           const w3 = await tree.get(Buffer.from('c'));
+           const w1 = tree.get(Buffer.from('a'));
+           const w2 = tree.get(Buffer.from('b'));
+           const w3 = tree.get(Buffer.from('c'));
 
            VerifyWitness(tree.root, Buffer.from('a'), w1);
            VerifyWitness(tree.root, Buffer.from('b'), w2);


### PR DESCRIPTION
This PR removes async from all the APIs, since there is no need to wait for disk writes anymore.

In addition, basic memoization is implemented which significantly speeds up the tree.
Compared to the original tree, performance is now at:

```
no-op: 202962±0.57% ops/s 0.005±0.0001 ms/op (78 runs)
put (empty tree): 166655±0.54% ops/s 0.006±0.0001 ms/op (77 runs)
get (empty tree): 132321±0.95% ops/s 0.008±0.0003 ms/op (79 runs)
generate 1k-10k-32-ran: 145±1.28% ops/s 6.908±0.3744 ms/op (69 runs)
generate 1k-1k-32-ran: 17.46±4.31% ops/s 57.265±8.7154 ms/op (48 runs)
generate 1k-1k-32-mir: 14.98±1.94% ops/s 66.776±5.5292 ms/op (70 runs)
generate 1k-9-32-ran: 1.32±2.24% ops/s 760.233±25.3012 ms/op (11 runs)
generate 1k-5-32-ran: 0.89±1.82% ops/s 1127.114±26.6204 ms/op (9 runs)
generate 1k-3-32-ran: 0.59±5.02% ops/s 1691.011±91.8426 ms/op (7 runs)
```

versus
```
put (empty tree): 19247±3.74% ops/s 0.052±0.0088 ms/op (79 runs)
get (empty tree): 115079±1.39% ops/s 0.009±0.0005 ms/op (78 runs)
generate 1k-1k-32-ran: 3.99±5.56% ops/s 250.683±33.0097 ms/op (24 runs)
generate 1k-1k-32-mir: 4.41±3.37% ops/s 226.868±18.8978 ms/op (26 runs)
generate 1k-9-32-ran: 4.59±4.10% ops/s 217.744±22.5524 ms/op (27 runs)
generate 1k-5-32-ran: 4.62±3.40% ops/s 216.660±18.6436 ms/op (27 runs)
generate 1k-3-32-ran: 4.48±3.60% ops/s 223.153±19.8981 ms/op (26 runs)
```

The tests with a small era size (9, 5, 3) are significantly slower because they calculate the root more often (10s of inserts rather than 1000s of inserts), resulting in more frequent serializations.