### PR TITLE
Fix issue with verify embedded-embedded

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -110,9 +110,9 @@ describe('Try simple 3 node test', () => {
     const w2 = tree.get(Buffer.from('123456'));
     const w3 = tree.get(Buffer.from('1234'));
 
-    w1.value!.should.deep.equal(Buffer.from('1'));
-    w2.value!.should.deep.equal(Buffer.from('2'));
-    w3.value!.should.deep.equal(Buffer.from('3'));
+    VerifyWitness(tree.root, Buffer.from('12345'), w1);
+    VerifyWitness(tree.root, Buffer.from('123456'), w2);
+    VerifyWitness(tree.root, Buffer.from('1234'), w3);
   });
 
   it('should work out of order', async () => {
@@ -124,9 +124,9 @@ describe('Try simple 3 node test', () => {
     const w2 = tree.get(Buffer.from('123456'));
     const w3 = tree.get(Buffer.from('1234'));
 
-    w1.value!.should.deep.equal(Buffer.from('1'));
-    w2.value!.should.deep.equal(Buffer.from('2'));
-    w3.value!.should.deep.equal(Buffer.from('3'));
+    VerifyWitness(tree.root, Buffer.from('12345'), w1);
+    VerifyWitness(tree.root, Buffer.from('123456'), w2);
+    VerifyWitness(tree.root, Buffer.from('1234'), w3);
   });
 });
 


### PR DESCRIPTION
This PR fixes three issues with VerifyWitness, mostly dealing with the treatment of embedded nodes.

1) VerifyWitness returns error when value is inside an embeddedbranch (closes #37)

2) VerifyWitness returns error when embedded branch is inside embedded extension (closes #36)

3) VerifyWitness returns error when value is inside of a branch node followed by an extension