### PR TITLE
Increase CI speed, deprecate node <10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
 - lts/*
 - '10'
@@ -8,13 +9,9 @@ env:
   - secure: EdR5wACv6IIsY25lpm6eG+2hLuXGyt2essusHj9eZqTmepMkwWa4kNNuV15/dQIwE9xOKIc4bFd+FMDTDdV9NEsrgrF7g4hqMsewaYHQsX6LJXhA8naQtwYEYadqE9i0HHEXaguvJeiE1m80FFAr713ZpLdSvjSvdWOqWWQrlmA18x/uYnWYqcK7shCugMkh6iZnE33/jINFfY7cVtQdVBNvLZ7g/QIrfZVThCadEVGv9UFwHgwpeXWJS8xxryvcEL0Y1PgO29vFNbHXb73s2iLRcFAEDJzu34P4CuzrCa1xbXsM7MiSqeSxNy2IsfFP+Ki6ebWkSYYaBBBIz1PBCNStyB6YaUHufZ8OemkZT/0Q+CUhPuQLfhzwY8ujArztORNjpDgOf3spWnVjOXDDQ2BubyRxP9MwSs2vzCeyEivhZ+xCSMJk1bSC2BMg6dAkyRjvO050gWvlTyBJq8tXcpNt9cxPqbFQbbVyDZNpmgfl/s7trU2420R6w4qqzqEBM1dzIV3ioV0yNQvK/iaBiyZnR6t2R3e9ulSSrDkKp21R+sgAiA9yqhm+QifTTCmCBPYIV6w4hUXOyRq+jm+5HZQajZGjDiuixJuKaM0GPrNiJYJ9cuk3k+7MdVqgKgoRBMunVS2XGXIGncnGFnUdjwlf0J4AbC899fs/dVW5YWs=
   - secure: eqJ43ZyFm8h10fYDH9uRzWN8YZsaaS62alACh44K24qZdLty701R1NTgcYxWZp5YQ0YtAQPmGIrTBCien8yHogobgcD0ZEjMuKXY90D4v5Rx3uVrio64NQGYtZZtA3OogyAaOULbx4MGKCrCPnkf5+uXGe3iVCGsGFS3+REmw+lEMgP9T8g7Uakmfgehi4ivST+tXe6s5bZwEBOXD6Iv3CF/2lmP/fh+kR6/zZZKbKgmPRZxiI5o6vly38NoCtkr5mBXuX20pZlEL7LBMGzEZ6IX8NFv3I2xyQ66gy0K/XMeQMDk8dpkSKxmv/gKi4OGy9wONrdtoXTePEs6zbKF+G7UjOp0GH5XTmT4KqHHoCXESZMMeVez6Uk45TJdf5Y9sgYbyfHmqklasbdXGScy/aT5eAlYVUw5UL0yksenCBPiTtfpvCOhwDwgYjOElT3D8k1cZUUJGSMC4TcIdFdluhv371aoz8gsnJ+k92OR48jTgUYtYG8UAJXxy88m/7t2fVUl+m/eF2uxlmokF2jm+MVNbUXqlFzG9h7WrNoct0TsyovUppF7dXITbaKS2d/0c/tUpPz7pEcBxB5LSqXviSNz1LeK9YsUZWKrfzgaPmTTKmDmuGpYCXbU9h8mBlBKk0QoHWwfLznITfV/2yu1fWq2+Oz5Z9RsEReSSycBSKE=
   matrix:
-  - CXX=g++-4.8 TEST_SUITE=test:node
+  - TEST_SUITE=test:node
 addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
+  chrome: stable
 before_install:
 - sh -e /etc/init.d/xvfb start
 matrix:
@@ -22,9 +19,7 @@ matrix:
   include:
   - os: linux
     node_js: '10'
-    env: CXX=g++-4.8 TEST_SUITE=test:browser
-before_script:
-- npm install -g typescript gts typedoc
+    env: TEST_SUITE=test:browser
 script: npm run $TEST_SUITE
 before_deploy:
 - npm run typedoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-- lts/*
+- node
 - '10'
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ addons:
   chrome: stable
 before_install:
 - sh -e /etc/init.d/xvfb start
+cache:
+  directories:
+   - $HOME/.npm
 matrix:
   fast_finish: true
   include:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![NPM Package](https://img.shields.io/npm/v/@rainblock/merkle-patricia-tree.svg?style=flat-square)](https://www.npmjs.org/package/@rainblock/merkle-patricia-tree)
 [![Build Status](https://img.shields.io/travis/com/RainBlock/merkle-patricia-tree.svg?branch=master&style=flat-square)](https://travis-ci.com/RainBlock/merkle-patricia-tree)
 [![Coverage Status](https://img.shields.io/coveralls/RainBlock/merkle-patricia-tree.svg?style=flat-square)](https://coveralls.io/r/RainBlock/merkle-patricia-tree)
+![node](https://img.shields.io/node/v/@rainblock/merkle-patricia-tree.svg)
 
 [@rainblock/merkle-patricia-tree](https://www.npmjs.org/package/@rainblock/merkle-patricia-tree) is an in-memory merkle tree which conforms to the specifications of the modified merkle patricia tree used by Ethereum. It is a fork of the [EthereumJS](https://github.com/ethereumjs) [library](https://github.com/ethereumjs/merkle-patricia-tree), and released under the same license, however, the API has changed to be synchronous instead of callback based. The goals of @rainblock/merkle-patricia-tree are to be:
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">= 10.0.0"
+  },
   "contributors": [
     "mjbecze <mjbecze@gmail.com>",
     "Aaron Kumavis <http://aaron.kumavis.me/> (https://github.com/kumavis)",


### PR DESCRIPTION
This PR increases the speed of CI by switching to the Travis container-based infrastructure.

It also deprecates Node <10 support, since BigInts aren't supported, and we will move to BigInts soon.
In a month, Node 10 will become LTS anyway. 

Node >10 is now a required dependency.