### PR TITLE
Use bigint-hash for hashing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -883,6 +883,23 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
       "dev": true
+    },
+    "bigint-buffer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.2.tgz",
+      "integrity": "sha512-gof9NgbodUgCXD2aUHfUKk5KUDk6/zPlwE+YYpRM2t7zS0K/6WipJFWfziIY+EavxFDuGUnuuQQzzvNcckPKNA==",
+      "requires": {
+        "bindings": "^1.3.0"
+      }
+    },
+    "bigint-hash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bigint-hash/-/bigint-hash-0.1.1.tgz",
+      "integrity": "sha512-oUY4CvxuTFGTvXSk/twRA0aAV6Ao0jOksZXYwOvKwrbjOqOLOZvLrulneNujRg0VOlnQnI9JdarcYgaIm/mzpA==",
+      "requires": {
+        "bigint-buffer": "^1.1.2",
+        "bindings": "^1.3.0"
+      }
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -5101,6 +5118,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
       "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+      "dev": true,
       "requires": {
         "bindings": "^1.2.1",
         "inherits": "^2.0.3",
@@ -5843,7 +5861,8 @@
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -8177,9 +8196,8 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "github:calebsander/TypeScript#2280877e21129af345b12962a72e4e1b9196d8fe",
+      "from": "github:calebsander/TypeScript#feature/bigint-lkg",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "async": "^1.4.2",
-    "keccak": "^1.4.0",
+    "bigint-hash": "^0.1.1",
     "level-ws": "0.0.0",
     "levelup": "^1.2.1",
     "memdown": "^1.0.0",
@@ -72,7 +72,7 @@
     "ts-loader": "^4.5.0",
     "ts-node": "^7.0.1",
     "typedoc": "^0.12.0",
-    "typescript": "~2.6.1",
+    "typescript": "github:calebsander/TypeScript#feature/bigint-lkg",
     "webpack": "^4.16.5",
     "webpack-cli": "^3.1.0"
   },

--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -1,9 +1,8 @@
 
 import * as benchmark from 'benchmark';
+import {hashAsBuffer, HashType} from 'bigint-hash';
 
 import {BatchPut, MerklePatriciaTree} from './index';
-
-const ethUtil = require('ethereumjs-util');
 
 // This file contains the benchmark test suite. It includes the benchmark and
 // some lightweight boilerplate code for running benchmark.js in async mode. To
@@ -67,8 +66,11 @@ const generateStandardTree =
       const tree = new MerklePatriciaTree();
       let batchOps: BatchPut[] = [];
       for (let i = 1; i <= rounds; i++) {
-        seed = ethUtil.sha3(seed);
-        batchOps.push({key: seed, val: symmetric ? seed : ethUtil.sha3(seed)});
+        seed = hashAsBuffer(HashType.KECCAK256, seed);
+        batchOps.push({
+          key: seed,
+          val: symmetric ? seed : hashAsBuffer(HashType.KECCAK256, seed)
+        });
         if (i % eraSize === 0) {
           seed = tree.batch(batchOps);
           batchOps = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
+import {hashAsBuffer, HashType} from 'bigint-hash';
 import {RlpDecode, RlpEncode, RlpItem, RlpList} from 'rlp-stream';
 
 const originalNode = require('./trieNode');
 const matchingNibbleLength = require('./util').matchingNibbleLength;
-const keccak = require('keccak');
 
 interface OriginalTreeNode {
   value: Buffer;
@@ -94,7 +94,7 @@ export abstract class MerklePatriciaTreeNode {
       if (rlpEncodedBuffer === null) {
         rlpEncodedBuffer = RlpEncode(this.serialize());
       }
-      this.memoizedHash = keccak('keccak256').update(rlpEncodedBuffer).digest();
+      this.memoizedHash = hashAsBuffer(HashType.KECCAK256, rlpEncodedBuffer);
     }
     return this.memoizedHash!;
   }
@@ -921,7 +921,7 @@ export function VerifyWitness(root: Buffer, key: Buffer, witness: Witness) {
   let cld;
 
   for (const [idx, serializedNode] of witness.proof.entries()) {
-    const hash = keccak('keccak256').update(serializedNode).digest();
+    const hash = hashAsBuffer(HashType.KECCAK256, serializedNode);
     if (Buffer.compare(hash, targetHash)) {
       throw new VerificationError(`Hash mismatch: expected ${
           targetHash.toString('hex')} got ${hash.toString('hex')}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,9 @@
     "rootDir": ".",
     "outDir": "build",
     "target" : "es2017",
-    "lib" : [ "es2017" ],
-    "sourceMap": true
+    "lib" : [ "es2017", "esnext.bigint" ],
+    "sourceMap": true,
+    "experimentalBigInt" : true
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
This PR switches from the keecak package to bigint-hash for hashing. This results in a 2x performance increase for hashing intensive functions, such as freshly calculating a root:

Before:
```
no-op: 198804±2.03% ops/s 0.005±0.0004 ms/op (60 runs)
put (empty tree): 172420±0.68% ops/s 0.006±0.0002 ms/op (80 runs)
get (empty tree): 137989±0.85% ops/s 0.007±0.0003 ms/op (71 runs)
generate 1k-10k-32-ran: 149±1.45% ops/s 6.719±0.4185 ms/op (71 runs)
generate 1k-1k-32-ran: 34.53±3.64% ops/s 28.962±4.4988 ms/op (70 runs)
generate 1k-1k-32-mir: 28.27±1.44% ops/s 35.376±2.1207 ms/op (67 runs)
generate 1k-9-32-ran: 12.76±1.32% ops/s 78.394±4.1429 ms/op (62 runs)
generate 1k-5-32-ran: 11.68±2.13% ops/s 85.588±7.0673 ms/op (58 runs)
generate 1k-3-32-ran: 10.88±1.70% ops/s 91.932±5.8518 ms/op (54 runs)
```

After:
```
no-op: 184645±2.05% ops/s 0.005±0.0005 ms/op (72 runs)
put (empty tree): 154683±1.50% ops/s 0.006±0.0004 ms/op (74 runs)
get (empty tree): 126926±2.51% ops/s 0.008±0.0009 ms/op (81 runs)
generate 1k-10k-32-ran: 700±2.64% ops/s 1.428±0.1674 ms/op (76 runs)
generate 1k-1k-32-ran: 66.53±7.66% ops/s 15.030±5.2846 ms/op (81 runs)
generate 1k-1k-32-mir: 61.69±1.38% ops/s 16.209±0.9778 ms/op (73 runs)
generate 1k-9-32-ran: 21.01±4.69% ops/s 47.607±8.3750 ms/op (54 runs)
generate 1k-5-32-ran: 20.23±4.25% ops/s 49.423±7.7204 ms/op (52 runs)
generate 1k-3-32-ran: 18.42±5.98% ops/s 54.278±11.4711 ms/op (48 runs)
```

