### PR TITLE
Memoize bigints when possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "An implementation of the modified merkle patricia tree used in Ethereum, optimized for in-memory usage",
   "main": "build/src/index.js",
   "types": "build/src/index.d.js",


### PR DESCRIPTION
Instead of memoizing buffers, this PR changes the behavior of the memoization code to memoize bigints.

Unfortunately, this does result in a small trade-off as branch nodes and extension nodes will need to convert to Buffers in order to generate a hash the first time/when they are changed.

It does yield an overall small performance increase, however.