### PR TITLE
Memoizing rlp encoding of nodes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,23 @@ export abstract class MerklePatriciaTreeNode<V> {
   abstract value: V|null;
 
   /**
+   * Memoizing RLP encoding of the serialized node
+   */
+  abstract rlpNodeEncoding: Buffer| null;
+
+  getRlpNodeEncoding(valueConverter: (val: V) => Buffer): Buffer {
+    if (this.rlpNodeEncoding === null) {
+      this.rlpNodeEncoding = RlpEncode(this.serialize(valueConverter));
+    }
+    return this.rlpNodeEncoding;
+  }
+
+  clearRlpNodeEncoding() {
+    this.rlpNodeEncoding = null;
+  }
+
+
+  /**
    * Serialize the node into a buffer or an array of buffers which may be RLP
    * serialized.
    */
@@ -97,7 +114,7 @@ export abstract class MerklePatriciaTreeNode<V> {
       rlpEncodedBuffer: Buffer|null = null): bigint {
     if (this.memoizedHash === null) {
       if (rlpEncodedBuffer === null) {
-        rlpEncodedBuffer = RlpEncode(this.serialize(valueConverter));
+        rlpEncodedBuffer = this.getRlpNodeEncoding(valueConverter);
       }
       this.memoizedHash = hashAsBigInt(HashType.KECCAK256, rlpEncodedBuffer);
     }
@@ -243,6 +260,8 @@ export class NullNode<V> extends MerklePatriciaTreeNode<V> {
   /** A null node always has no nibbles. */
   readonly nibbles = [];
 
+  rlpNodeEncoding = RlpEncode(Buffer.from([]));
+
   /** The value of a null node cannot be set. */
   set value(val: V) {
     throw new Error('Attempted to set the value of a NullNode');
@@ -280,6 +299,8 @@ export class BranchNode<V> extends MerklePatriciaTreeNode<V> {
   readonly nibbles: number[] = [];
   /** The value this branch holds, initially unset. */
   value: V|null = null;
+
+  rlpNodeEncoding: Buffer | null = null;
 
   /** An array of branches this tree node holds. */
   branches: Array<MerklePatriciaTreeNode<V>> =
@@ -362,7 +383,7 @@ export class BranchNode<V> extends MerklePatriciaTreeNode<V> {
             (branch as MerklePatriciaTreeNode<V>).hash(valueConverter), 32);
       } else {
         const serialized = branch.serialize(valueConverter);
-        const rlpEncoded = RlpEncode(serialized);
+        const rlpEncoded = branch.getRlpNodeEncoding(valueConverter);
         hashedBranches[idx] = (rlpEncoded.length >= 32) ?
             toBufferBE(
                 branch.hash(valueConverter, rlpEncoded),
@@ -388,6 +409,8 @@ export class ExtensionNode<V> extends MerklePatriciaTreeNode<V> {
   static PREFIX_EXTENSION_ODD = 1;
   /** The prefix when the number of nibbles in the extension node is even. */
   static PREFIX_EXTENSION_EVEN = 0;
+
+  rlpNodeEncoding: Buffer | null = null;
 
   /**
    * Return the prefix for this extension node.
@@ -432,9 +455,10 @@ export class ExtensionNode<V> extends MerklePatriciaTreeNode<V> {
   /** @inheritdoc */
   serialize(valueConverter: (val: V) => Buffer) {
     const serialized = this.nextNode!.serialize(valueConverter);
+    const rlpEncodeNextNode = this.nextNode!.getRlpNodeEncoding(valueConverter);
     return [
       MerklePatriciaTreeNode.toBuffer(this.nibbles, this.prefix),
-      RlpEncode(serialized).length >= 32 ?
+      rlpEncodeNextNode.length >= 32 ?
           toBufferBE(this.nextNode!.hash(valueConverter), 32) :
           serialized
     ];
@@ -467,6 +491,8 @@ export class LeafNode<V> extends MerklePatriciaTreeNode<V> {
   private static PREFIX_LEAF_ODD = 3;
   /** The prefix of the leaf node if the number of nibbles is even. */
   private static PREFIX_LEAF_EVEN = 2;
+
+  rlpNodeEncoding: Buffer | null = null;
 
   /**
    * Constructs a new leaf node with the given nibbles and value.
@@ -672,6 +698,7 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
       // Clear all memoized hashes in the path, they will be reset.
       for (const node of result.stack) {
         node.clearMemoizedHash();
+        node.clearRlpNodeEncoding();
       }
     }
   }
@@ -865,7 +892,7 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
 
     const proof: Buffer[] = [];
     for (const [idx, node] of search.stack.entries()) {
-      const rlp = RlpEncode(node.serialize(this.convertValue));
+      const rlp = node.getRlpNodeEncoding(this.convertValue);
       if (rlp.length >= 32 || (idx === 0)) {
         proof.push(rlp);
       }
@@ -886,6 +913,7 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
       // Clear all memoized hashes in the path, they will be reset.
       for (const node of result.stack) {
         node.clearMemoizedHash();
+        node.clearRlpNodeEncoding();
       }
       if (result.node instanceof BranchNode) {
         result.node.value = Buffer.from([]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,10 @@ export abstract class MerklePatriciaTreeNode<V> {
    */
   abstract rlpNodeEncoding: Buffer| null;
 
+  /**
+   * Serialzes and computed the RLP encoding of the node
+   * Also stores it for future references.
+   */
   getRlpNodeEncoding(valueConverter: (val: V) => Buffer): Buffer {
     if (this.rlpNodeEncoding === null) {
       this.rlpNodeEncoding = RlpEncode(this.serialize(valueConverter));
@@ -78,6 +82,9 @@ export abstract class MerklePatriciaTreeNode<V> {
     return this.rlpNodeEncoding;
   }
 
+  /**
+   * Clears the memoized RLP node encoding
+   */
   clearRlpNodeEncoding() {
     this.rlpNodeEncoding = null;
   }


### PR DESCRIPTION
We introduce memoization for the rlpEncodings of serialized nodes.

Current benchmarks:
```
no-op: 192580±1.06% ops/s 0.005±0.0003 ms/op (82 runs)
put (empty tree): 155309±1.09% ops/s 0.006±0.0003 ms/op (79 runs)
get (empty tree): 165504±1.38% ops/s 0.006±0.0004 ms/op (81 runs)
individual bulk get: 42383±1.41% ops/s 0.024±0.0006 ms/op (17 runs)
individual get 1: 138877±9.43% ops/s 0.007±0.0013 ms/op (17 runs)
generate 1k-10k-32-ran: 691±2.33% ops/s 1.448±0.1520 ms/op (78 runs)
generate 1k-1k-32-ran: 66.64±1.88% ops/s 15.005±1.2702 ms/op (78 runs)
generate 1k-1k-32-mir: 55.44±4.08% ops/s 18.039±3.0722 ms/op (67 runs)
generate 1k-9-32-ran: 21.55±4.91% ops/s 46.396±8.5370 ms/op (54 runs)
generate 1k-5-32-ran: 18.47±7.96% ops/s 54.130±15.0786 ms/op (47 runs)
generate 1k-3-32-ran: 18.14±3.89% ops/s 55.134±8.4795 ms/op (60 runs)
```

Previous results:
```
no-op: 197222±1.53% ops/s 0.005±0.0004 ms/op (79 runs)
put (empty tree): 153519±1.04% ops/s 0.007±0.0003 ms/op (77 runs)
get (empty tree): 127997±2.08% ops/s 0.008±0.0007 ms/op (81 runs)
individual bulk get: 748±3.81% ops/s 1.336±0.1023 ms/op (18 runs)
individual get 1: 10920±1.53% ops/s 0.092±0.0027 ms/op (17 runs)
generate 1k-10k-32-ran: 706±2.15% ops/s 1.416±0.1372 ms/op (78 runs)
generate 1k-1k-32-ran: 68.84±1.15% ops/s 14.527±0.7603 ms/op (80 runs)
generate 1k-1k-32-mir: 60.84±0.95% ops/s 16.435±0.6790 ms/op (72 runs)
generate 1k-9-32-ran: 21.21±2.87% ops/s 47.154±5.0208 ms/op (53 runs)
generate 1k-5-32-ran: 19.30±2.83% ops/s 51.823±5.2452 ms/op (49 runs)
generate 1k-3-32-ran: 17.27±2.86% ops/s 57.920±7.4610 ms/op (78 runs)
```

We observe a speedup of 56x in case of individual bulk gets and 12x in case of a single individual get.