### PR TITLE
Don't serialize nodes when get() is called

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "3.2.1",
+  "version": "4.0.0",
   "description": "An implementation of the modified merkle patricia tree used in Ethereum, optimized for in-memory usage",
   "main": "build/src/index.js",
   "types": "build/src/index.d.js",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,7 +4,7 @@ import * as chai from 'chai';
 import * as path from 'path';
 import {RlpEncode, RlpList} from 'rlp-stream';
 
-import {MerklePatriciaTree, VerifyWitness} from './index';
+import {MerklePatriciaTree, verifyWitness} from './index';
 
 
 
@@ -166,17 +166,22 @@ describe('Try simple 3 node test', () => {
     const w2 = tree.get(Buffer.from('123456'));
     const w3 = tree.get(Buffer.from('1234'));
 
-    VerifyWitness(tree.root, Buffer.from('12345'), w1);
-    VerifyWitness(tree.root, Buffer.from('123456'), w2);
-    VerifyWitness(tree.root, Buffer.from('1234'), w3);
+    verifyWitness(
+        tree.root, Buffer.from('12345'), tree.rlpSerializeWitness(w1));
+    verifyWitness(
+        tree.root, Buffer.from('123456'), tree.rlpSerializeWitness(w2));
+    verifyWitness(tree.root, Buffer.from('1234'), tree.rlpSerializeWitness(w3));
   });
 
   it('Should verify batch get in forward mode', async () => {
-    const W = tree.batchGet(
+    const w = tree.batchGet(
         [Buffer.from('12345'), Buffer.from('123456'), Buffer.from('1234')]);
-    VerifyWitness(tree.root, Buffer.from('12345'), W[0]);
-    VerifyWitness(tree.root, Buffer.from('123456'), W[1]);
-    VerifyWitness(tree.root, Buffer.from('1234'), W[2]);
+    verifyWitness(
+        tree.root, Buffer.from('12345'), tree.rlpSerializeWitness(w[0]));
+    verifyWitness(
+        tree.root, Buffer.from('123456'), tree.rlpSerializeWitness(w[1]));
+    verifyWitness(
+        tree.root, Buffer.from('1234'), tree.rlpSerializeWitness(w[2]));
   });
 
   it('should work out of order', async () => {
@@ -188,17 +193,22 @@ describe('Try simple 3 node test', () => {
     const w2 = tree.get(Buffer.from('123456'));
     const w3 = tree.get(Buffer.from('1234'));
 
-    VerifyWitness(tree.root, Buffer.from('12345'), w1);
-    VerifyWitness(tree.root, Buffer.from('123456'), w2);
-    VerifyWitness(tree.root, Buffer.from('1234'), w3);
+    verifyWitness(
+        tree.root, Buffer.from('12345'), tree.rlpSerializeWitness(w1));
+    verifyWitness(
+        tree.root, Buffer.from('123456'), tree.rlpSerializeWitness(w2));
+    verifyWitness(tree.root, Buffer.from('1234'), tree.rlpSerializeWitness(w3));
   });
 
   it('Should verify batch get out of order', async () => {
-    const W = tree.batchGet(
+    const w = tree.batchGet(
         [Buffer.from('12345'), Buffer.from('123456'), Buffer.from('1234')]);
-    VerifyWitness(tree.root, Buffer.from('12345'), W[0]);
-    VerifyWitness(tree.root, Buffer.from('123456'), W[1]);
-    VerifyWitness(tree.root, Buffer.from('1234'), W[2]);
+    verifyWitness(
+        tree.root, Buffer.from('12345'), tree.rlpSerializeWitness(w[0]));
+    verifyWitness(
+        tree.root, Buffer.from('123456'), tree.rlpSerializeWitness(w[1]));
+    verifyWitness(
+        tree.root, Buffer.from('1234'), tree.rlpSerializeWitness(w[2]));
   });
 });
 
@@ -354,9 +364,9 @@ describe('Try batch operations', () => {
     const w2 = tree.get(Buffer.from('b'));
     const w3 = tree.get(Buffer.from('c'));
 
-    VerifyWitness(root, Buffer.from('a'), w1);
-    VerifyWitness(root, Buffer.from('b'), w2);
-    VerifyWitness(root, Buffer.from('c'), w3);
+    verifyWitness(root, Buffer.from('a'), tree.rlpSerializeWitness(w1));
+    verifyWitness(root, Buffer.from('b'), tree.rlpSerializeWitness(w2));
+    verifyWitness(root, Buffer.from('c'), tree.rlpSerializeWitness(w3));
   });
 
   it('put simple batch verifying with batch get', async () => {
@@ -367,11 +377,11 @@ describe('Try batch operations', () => {
       {key: Buffer.from('c'), val: Buffer.from('c')}
     ]);
 
-    const W =
+    const w =
         tree.batchGet([Buffer.from('a'), Buffer.from('b'), Buffer.from('c')]);
-    VerifyWitness(root, Buffer.from('a'), W[0]);
-    VerifyWitness(root, Buffer.from('b'), W[1]);
-    VerifyWitness(root, Buffer.from('c'), W[2]);
+    verifyWitness(root, Buffer.from('a'), tree.rlpSerializeWitness(w[0]));
+    verifyWitness(root, Buffer.from('b'), tree.rlpSerializeWitness(w[1]));
+    verifyWitness(root, Buffer.from('c'), tree.rlpSerializeWitness(w[2]));
   });
 
   it('put and del a simple batch', async () => {
@@ -390,9 +400,9 @@ describe('Try batch operations', () => {
     const w2 = tree.get(Buffer.from('b'));
     const w3 = tree.get(Buffer.from('c'));
 
-    VerifyWitness(root, Buffer.from('a'), w1);
-    VerifyWitness(root, Buffer.from('b'), w2);
-    VerifyWitness(root, Buffer.from('c'), w3);
+    verifyWitness(root, Buffer.from('a'), tree.rlpSerializeWitness(w1));
+    verifyWitness(root, Buffer.from('b'), tree.rlpSerializeWitness(w2));
+    verifyWitness(root, Buffer.from('c'), tree.rlpSerializeWitness(w3));
 
     const w4 = tree.get(Buffer.from('d'));
     should.not.exist(w4.value);
@@ -410,11 +420,11 @@ describe('Try batch operations', () => {
         ],
         [Buffer.from('d')]);
 
-    const W =
+    const w =
         tree.batchGet([Buffer.from('a'), Buffer.from('b'), Buffer.from('c')]);
-    VerifyWitness(root, Buffer.from('a'), W[0]);
-    VerifyWitness(root, Buffer.from('b'), W[1]);
-    VerifyWitness(root, Buffer.from('c'), W[2]);
+    verifyWitness(root, Buffer.from('a'), tree.rlpSerializeWitness(w[0]));
+    verifyWitness(root, Buffer.from('b'), tree.rlpSerializeWitness(w[1]));
+    verifyWitness(root, Buffer.from('c'), tree.rlpSerializeWitness(w[2]));
   });
 
   it('put and del a simple batch with overlap', async () => {
@@ -431,8 +441,8 @@ describe('Try batch operations', () => {
     const w2 = tree.get(Buffer.from('b'));
     const w3 = tree.get(Buffer.from('c'));
 
-    VerifyWitness(root, Buffer.from('a'), w1);
-    VerifyWitness(root, Buffer.from('b'), w2);
+    verifyWitness(root, Buffer.from('a'), tree.rlpSerializeWitness(w1));
+    verifyWitness(root, Buffer.from('b'), tree.rlpSerializeWitness(w2));
     should.not.exist(w3.value);
   });
 
@@ -447,8 +457,8 @@ describe('Try batch operations', () => {
            ],
            [Buffer.from('c')]);
 
-       const W = tree.batchGet([Buffer.from('a'), Buffer.from('b')]);
-       VerifyWitness(root, Buffer.from('a'), W[0]);
-       VerifyWitness(root, Buffer.from('b'), W[1]);
+       const w = tree.batchGet([Buffer.from('a'), Buffer.from('b')]);
+       verifyWitness(root, Buffer.from('a'), tree.rlpSerializeWitness(w[0]));
+       verifyWitness(root, Buffer.from('b'), tree.rlpSerializeWitness(w[1]));
      });
 });

--- a/src/proof.spec.ts
+++ b/src/proof.spec.ts
@@ -4,7 +4,7 @@ import * as chai from 'chai';
 import * as path from 'path';
 import {RlpEncode, RlpList} from 'rlp-stream';
 
-import {MerklePatriciaTree, VerifyWitness} from './index';
+import {MerklePatriciaTree, verifyWitness} from './index';
 
 
 
@@ -34,9 +34,12 @@ describe(
         const w2 = tree.get(Buffer.from('key2bb'));
         const w3 = tree.get(Buffer.from('key3cc'));
 
-        VerifyWitness(tree.root, Buffer.from('key1aa'), w1);
-        VerifyWitness(tree.root, Buffer.from('key2bb'), w2);
-        VerifyWitness(tree.root, Buffer.from('key3cc'), w3);
+        verifyWitness(
+            tree.root, Buffer.from('key1aa'), tree.rlpSerializeWitness(w1));
+        verifyWitness(
+            tree.root, Buffer.from('key2bb'), tree.rlpSerializeWitness(w2));
+        verifyWitness(
+            tree.root, Buffer.from('key3cc'), tree.rlpSerializeWitness(w3));
       });
 
       it('should create a merkle proof and verify it with a single long key',
@@ -45,14 +48,16 @@ describe(
                Buffer.from('key1aa'),
                Buffer.from('0123456789012345678901234567890123456789xx'));
            const w1 = tree.get(Buffer.from('key1aa'));
-           VerifyWitness(tree.root, Buffer.from('key1aa'), w1);
+           verifyWitness(
+               tree.root, Buffer.from('key1aa'), tree.rlpSerializeWitness(w1));
          });
 
       it('should create a merkle proof and verify it with a single short key',
          async () => {
            tree.put(Buffer.from('key1aa'), Buffer.from('01234'));
            const w1 = tree.get(Buffer.from('key1aa'));
-           VerifyWitness(tree.root, Buffer.from('key1aa'), w1);
+           verifyWitness(
+               tree.root, Buffer.from('key1aa'), tree.rlpSerializeWitness(w1));
          });
 
       it('should create a merkle proof with keys in the middle', async () => {
@@ -73,9 +78,12 @@ describe(
         const w2 = tree.get(Buffer.from('key2'));
         const w3 = tree.get(Buffer.from('key3'));
 
-        VerifyWitness(tree.root, Buffer.from('key1'), w1);
-        VerifyWitness(tree.root, Buffer.from('key2'), w2);
-        VerifyWitness(tree.root, Buffer.from('key3'), w3);
+        verifyWitness(
+            tree.root, Buffer.from('key1'), tree.rlpSerializeWitness(w1));
+        verifyWitness(
+            tree.root, Buffer.from('key2'), tree.rlpSerializeWitness(w2));
+        verifyWitness(
+            tree.root, Buffer.from('key3'), tree.rlpSerializeWitness(w3));
       });
 
 
@@ -89,8 +97,11 @@ describe(
            const w2 = tree.get(Buffer.from('b'));
            const w3 = tree.get(Buffer.from('c'));
 
-           VerifyWitness(tree.root, Buffer.from('a'), w1);
-           VerifyWitness(tree.root, Buffer.from('b'), w2);
-           VerifyWitness(tree.root, Buffer.from('c'), w3);
+           verifyWitness(
+               tree.root, Buffer.from('a'), tree.rlpSerializeWitness(w1));
+           verifyWitness(
+               tree.root, Buffer.from('b'), tree.rlpSerializeWitness(w2));
+           verifyWitness(
+               tree.root, Buffer.from('c'), tree.rlpSerializeWitness(w3));
          });
     });


### PR DESCRIPTION
This PR changes the behavior of get() so that nodes are not serialized when a witness is retrieved.

Instead, a new function, rlpSerializeWitness() must be called if you wish to obtain a serialized witness to be passed into verifyWitness.

Also, the API previously known as VerifyWitness has been renamed to verifyWitness to match code conventions.
