### PR TITLE
:Bug: Fixing del operation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -794,6 +794,25 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
     return new NullNode<V>();
   }
 
+  private copyPath(key: K, newTree: MerklePatriciaTree<K, V>, flag?:boolean) {
+    let keyNibbles: number[] =
+        MerklePatriciaTreeNode.bufferToNibbles(this.options.keyConverter!(key));
+    let currNode: MerklePatriciaTreeNode<V>|null = newTree.rootNode;
+    let nextNode: MerklePatriciaTreeNode<V>|null;
+    const result: SearchResult<V> = this.search(key);
+    for (let i = 1; i < result.stack.length; i++) {
+      nextNode = this.getNodeCopy(result.stack[i]);
+      if (currNode instanceof BranchNode) {
+        currNode.branches[keyNibbles[0]] = nextNode;
+        keyNibbles.shift();
+      } else if (currNode instanceof ExtensionNode) {
+        currNode.nextNode = nextNode;
+        keyNibbles = keyNibbles.slice(currNode.nibbles.length);
+      }
+      currNode = nextNode;
+    }
+  }
+
   /**
    * Copy on write batch puts to MerklePatriciaTree
    * @param putOps List of PutOps
@@ -804,48 +823,11 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
     const newTree = new MerklePatriciaTree<K, V>(this.options);
     newTree.rootNode = this.getNodeCopy(this.rootNode);
     for (const put of putOps) {
-      if (newTree.rootNode instanceof NullNode) {
-        newTree.rootNode = new LeafNode(
-            MerklePatriciaTreeNode.bufferToNibbles(this.options.keyConverter!
-                                                   (put.key)),
-            put.val);
-      } else {
-        let keyNibbles: number[] = MerklePatriciaTreeNode.bufferToNibbles(
-            this.options.keyConverter!(put.key));
-        let currNode: MerklePatriciaTreeNode<V>|null = newTree.rootNode;
-        let nextNode: MerklePatriciaTreeNode<V>|null;
-        const result: SearchResult<V> = this.search(put.key);
-        for (let i = 1; i < result.stack.length; i++) {
-          nextNode = this.getNodeCopy(result.stack[i]);
-          if (currNode instanceof BranchNode) {
-            currNode.branches[keyNibbles[0]] = nextNode;
-            keyNibbles.shift();
-          } else if (currNode instanceof ExtensionNode) {
-            currNode.nextNode = nextNode;
-            keyNibbles = keyNibbles.slice(currNode.nibbles.length);
-          }
-          currNode = nextNode;
-        }
-        newTree.put(put.key, put.val);
-      }
+      this.copyPath(put.key, newTree);
+      newTree.put(put.key, put.val);
     }
     for (const key of delOps) {
-      let keyNibbles: number[] = MerklePatriciaTreeNode.bufferToNibbles(
-          this.options.keyConverter!(key));
-      let currNode: MerklePatriciaTreeNode<V>|null = newTree.rootNode;
-      let nextNode: MerklePatriciaTreeNode<V>|null;
-      const result: SearchResult<V> = this.search(key);
-      for (let i = 1; i < result.stack.length; i++) {
-        nextNode = this.getNodeCopy(result.stack[i]);
-        if (currNode instanceof BranchNode) {
-          currNode.branches[keyNibbles[0]] = nextNode;
-          keyNibbles.shift();
-        } else if (currNode instanceof ExtensionNode) {
-          currNode.nextNode = nextNode;
-          keyNibbles = keyNibbles.slice(currNode.nibbles.length);
-        }
-        currNode = nextNode;
-      }
+      this.copyPath(key, newTree, true);
       newTree.del(key);
     }
     return newTree;
@@ -1246,6 +1228,8 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
                       // Update the leaf node with the extension's nibbles
                       connectNode.nextNode.nibbles = connectNode.nibbles.concat(
                           connectNode.nextNode.nibbles);
+                      branchParent.branches[idx].clearMemoizedHash();
+                      branchParent.branches[idx].clearRlpNodeEncoding();
                     } else {
                       // Otherwise, attach the extension
                       branchParent.branches[idx] = connectNode;


### PR DESCRIPTION
This PR fixes `tree.del()` operation.

If we perform a `tree.root` query in between multiple `tree.del()` operations, the root hash of the tree differs from the expected value. The memoized hashes are not cleared in a corner case, while performing deletes. This PR clears the node hashes.

`Case:`
Consider deleting from the path [..., branch_node, target_node]. After deleting the target_node if branch_node has only one branch remaining, a connecting node is used to collapse the branch and the branch_node. The memoized hash of the connecting node is not cleared. This results in the root hash mismatch.

`TestCase to reproduce the bug:`
Insert a `tree.root` in any of the `secure trieTests` in `src/official.spec.ts` while performing inserts and deletes to observe that the root hashes mismatch.