### PR TITLE
Batch using loops

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -33,7 +33,7 @@ describe('Try original simple-save-retrieve', () => {
   });
 
   it('should batch get a value', async () => {
-    const val1 = tree.batchGet([Buffer.from('test')]);
+    const val1 = tree.batchGet(['test']);
     const val = tree.get('test');
     val.value!.should.deep.equal(val1[0].value);
     for (let i = 0; i < val.proof.length; i++) {
@@ -49,7 +49,7 @@ describe('Try original simple-save-retrieve', () => {
   });
 
   it('should batch get an updated value', async () => {
-    const val1 = tree.batchGet([Buffer.from('test')]);
+    const val1 = tree.batchGet(['test']);
     const val = tree.get('test');
     val.value!.should.deep.equal(val1[0].value);
     for (let i = 0; i < val.proof.length; i++) {
@@ -73,7 +73,7 @@ describe('Try original simple-save-retrieve', () => {
   });
 
   it('should batch get an updated value', async () => {
-    const val1 = tree.batchGet([Buffer.from('test')]);
+    const val1 = tree.batchGet(['test']);
     const val = tree.get('test');
     val.value!.should.deep.equal(val1[0].value);
     for (let i = 0; i < val.proof.length; i++) {
@@ -94,7 +94,7 @@ describe('Try original simple-save-retrieve', () => {
   });
 
   it('should batch get value from branch', async () => {
-    const val1 = tree.batchGet([Buffer.from('doge')]);
+    const val1 = tree.batchGet(['doge']);
     const val = tree.get('doge');
     val.value!.should.deep.equal(val1[0].value);
     for (let i = 0; i < val.proof.length; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1040,29 +1040,17 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
     return {value, proof};
   }
 
-  radixSort(keys: Buffer[]) {
-    keys.sort((k1, k2) => k1.compare(k2));
-  }
-
   /**
    * Reads multiple keys and returns a concise reply of witnesses
    * @param keys : bulk keys to be read
    * @returns : Array of witnesses
    */
-  batchGet(keys: Buffer[]): Array<Witness<V>> {
-    const sortedKeys = keys.slice(0);
-    this.radixSort(sortedKeys);
-    const sortedNibbles: number[][] = [];
-    for (const key of sortedKeys) {
-      sortedNibbles.push(MerklePatriciaTreeNode.bufferToNibbles(key));
+  batchGet(keys: K[]): Array<Witness<V>> {
+    const reply = [];
+    for (const key of keys) {
+      reply.push(this.get(key));
     }
-    const reply = this.getKeys(sortedNibbles);
-    const unsortedReply: Array<Witness<V>> = [];
-    for (let i = 0; i < sortedKeys.length; i++) {
-      const sk = sortedKeys[i];
-      unsortedReply[keys.findIndex(key => key.compare(sk) === 0)] = reply[i];
-    }
-    return unsortedReply;
+    return reply;
   }
 
   /**
@@ -1081,107 +1069,6 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
       }
     }
     return true;
-  }
-
-  private getKeys(keys: number[][]): Array<Witness<V>> {
-    const reply: Array<Witness<V>> = [];
-    let currNode = this.rootNode;
-    let nodesInPath: Array<MerklePatriciaTreeNode<V>> = [];
-    let nibIndex = 0;
-    for (let keyIndex = 0; keyIndex < keys.length; keyIndex++) {
-      const key = keys[keyIndex];
-      let readComplete = 0;
-      while (true) {
-        if (currNode instanceof BranchNode) {
-          if (nibIndex !== -1) {
-            nodesInPath.push(currNode);
-            currNode = currNode.branches[key[nibIndex]];
-            nibIndex += 1;
-            if (nibIndex >= key.length) {
-              nibIndex = -1;
-            }
-          } else if (nibIndex === -1 && currNode.value.length !== 0) {
-            nodesInPath.push(currNode);
-            const wit: Witness<V> = {value: currNode.value, proof: nodesInPath};
-            reply.push(wit);
-            readComplete = 1;
-          } else {
-            throw new Error('key doesn\'t match at BranchNode');
-          }
-        } else if (currNode instanceof ExtensionNode) {
-          if (nibIndex !== -1) {
-            if (this.areNibbleArraysEqual(
-                    key.slice(nibIndex, nibIndex + currNode.nibbles.length),
-                    currNode.nibbles) === true) {
-              nibIndex += currNode.nibbles.length;
-              if (nibIndex >= key.length) {
-                nibIndex = -1;
-              }
-              nodesInPath.push(currNode);
-              currNode = currNode.nextNode;
-            } else {
-              throw new Error('key doesn\'t match at ExtensionNode');
-            }
-          } else if (nibIndex === -1 && currNode.nibbles.length === 0) {
-            nodesInPath.push(currNode);
-            currNode = currNode.nextNode;
-          } else {
-            throw new Error('key doesn\'t match at ExtensionNode');
-          }
-        } else if (currNode instanceof LeafNode) {
-          if ((nibIndex === -1 && currNode.nibbles.length === 0) ||
-              (nibIndex !== -1 &&
-               this.areNibbleArraysEqual(
-                   key.slice(nibIndex, nibIndex + currNode.nibbles.length),
-                   currNode.nibbles) === true)) {
-            nodesInPath.push(currNode);
-            readComplete = 1;
-            const wit: Witness<V> = {value: currNode.value, proof: nodesInPath};
-            reply.push(wit);
-          } else {
-            throw new Error('Key doesn\'t match at LeafNode!');
-          }
-        } else if (currNode instanceof NullNode) {
-          throw new Error('Didn\'t expect a NullNode here!');
-        }
-
-        if (readComplete === 1) {
-          if (keyIndex === keys.length - 1) {
-            return reply;
-          }
-          const nextKey = keys[keyIndex + 1];
-          let start = key.length;
-          if (this.areNibbleArraysEqual(
-                  nextKey.slice(0, 10), key.slice(0, 10)) === false) {
-            currNode = this.rootNode;
-            nibIndex = 0;
-            nodesInPath = [];
-            readComplete = 0;
-            break;
-          }
-          while (start > nextKey.length ||
-                 this.areNibbleArraysEqual(
-                     key.slice(0, start), nextKey.slice(0, start)) === false) {
-            currNode = nodesInPath[nodesInPath.length - 1];
-            nodesInPath.pop();
-            if (currNode instanceof BranchNode) {
-              start--;
-            } else if (currNode instanceof ExtensionNode) {
-              start -= currNode.nibbles.length;
-            } else if (currNode instanceof LeafNode) {
-              start -= currNode.nibbles.length;
-            } else if (currNode instanceof NullNode) {
-              throw new Error('Didn\'t expect a NullNode here!');
-            }
-          }
-          nibIndex = start;
-          readComplete = 0;
-          nodesInPath.pop();
-          break;
-        }
-      }
-    }
-    return reply;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1054,24 +1054,6 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
   }
 
   /**
-   * Checks if two nibble arrays are equal or not
-   * @param arr1 : First nibble array
-   * @param arr2 : Second nibble array
-   * @returns bool : True if nibble arrays are equal and false otherwise
-   */
-  areNibbleArraysEqual(arr1: number[], arr2: number[]): boolean {
-    if (arr1.length !== arr2.length) {
-      return false;
-    }
-    for (let i = 0; i < arr1.length; i++) {
-      if (arr1[i] !== arr2[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /**
    * Given a key, delete any mapping that exists for that key.
    *
    * @param key   The key to unmap.


### PR DESCRIPTION
From #52 Memoizing rlp-encoding of serialized nodes - We get a speedup of 56x in case of individual bulk gets and 12x in case of a single individual get.

So, batchGet and batchPut using radix-sort are no longer more performant than multiple individual gets and puts. For more detailed explanation read #68 

Benchmark results:
```
no-op: 235889±0.46% ops/s 0.004±0.0001 ms/op (69 runs)
put (empty tree): 184552±0.89% ops/s 0.005±0.0002 ms/op (83 runs)
get (empty tree): 197534±0.79% ops/s 0.005±0.0002 ms/op (84 runs)
generate 1k-10k-32-ran: 734±2.20% ops/s 1.362±0.1344 ms/op (77 runs)
generate 1k-1k-32-ran: 70.51±6.93% ops/s 14.183±4.5429 ms/op (82 runs)
generate 1k-1k-32-mir: 66.60±0.87% ops/s 15.016±0.5834 ms/op (76 runs)
generate 1k-9-32-ran: 20.79±1.37% ops/s 48.090±2.4477 ms/op (53 runs)
generate 1k-5-32-ran: 20.14±0.87% ops/s 49.661±1.5738 ms/op (51 runs)
generate 1k-3-32-ran: 17.49±0.74% ops/s 57.169±1.9060 ms/op (79 runs)
individual bulk get: 60037±13.43% ops/s 0.017±0.0045 ms/op (18 runs)
bulk get: 59421±2.33% ops/s 0.017±0.0007 ms/op (16 runs)
individual get 1: 172976±3.43% ops/s 0.006±0.0004 ms/op (17 runs)
bulk get 1: 180338±1.95% ops/s 0.006±0.0002 ms/op (18 runs)

```

closes #68.