### PR TITLE
Efficient batchCOW

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -816,8 +816,10 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
       if (node1 instanceof BranchNode && node2 instanceof BranchNode) {
         for (let branchIdx = 0; branchIdx < node1.branches.length;
              branchIdx += 1) {
-          this.copyTreePaths(
+          if (node1.branches[branchIdx]) {
+            this.copyTreePaths(
               node1.branches[branchIdx], node2.branches[branchIdx]);
+          }
         }
       } else if (
           node1 instanceof ExtensionNode && node2 instanceof ExtensionNode) {


### PR DESCRIPTION
Efficient batchCOW by eliminating redundant node copies.
Nodes that have to be copied are marked for all the keys in the batch and are copied once at the end. The keys from the copied nodes are then modified.

Bottom line: 
Takes almost the same amount of the time as the batchCOW implementation in master, but reduces the total amount of heap required for performing the copy on write insert.

15K keys on an initially empty-tree:
```
batch insert on empty: 4.38±4.51% ops/s 228.305±25.4993 ms/op (26 runs)
batchCOW on empty: 4.39±1.37% ops/s 228.024±7.7195 ms/op (26 runs)
```

This PR
```
batchSize : 15K
batch insert into empty: 4.35±3.49% ops/s 230.126±19.8758 ms/op (26 runs)
batchCOW from prev: 2.10±2.09% ops/s 476.091±17.9618 ms/op (15 runs)
batchSize : 150K
batch insert: 0.38±1.65% ops/s 2663.477±41.9074 ms/op (6 runs)
batchCOW insert: 0.16±2.15% ops/s 6335.331±109.8624 ms/op (5 runs)
```

master:
```
batchSize : 15K
batch insert into empty: 4.42±3.46% ops/s 226.371±19.3706 ms/op (26 runs)
batchCOW from prev: 2.10±3.24% ops/s 476.666±27.8696 ms/op (15 runs)
batchSize : 150K
batch insert: 0.37±2.45% ops/s 2679.916±62.5608 ms/op (6 runs)
batchCOW insert: 0.17±3.68% ops/s 6010.782±178.0453 ms/op (5 runs)
```