### PR TITLE
Pruned tree doesn't throw error test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "An implementation of the modified merkle patricia tree used in Ethereum, optimized for in-memory usage",
   "main": "build/src/index.js",
   "types": "build/src/index.d.js",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -757,6 +757,29 @@ describe('test cached merkle tree', async () => {
   });
 });
 
+describe('test cached merkle tree', async () => {
+  it('should not be able to read pruned account', async () => {
+    const tree = new CachedMerklePatriciaTree({putCanDelete: false}, 2);
+    const data = require('../test/initial_accounts.json') as string[];
+    const errorAccount =
+        Buffer.from('2910543af39aba0cd09dbb2d50200b3e800a63d2', 'hex');
+    const value = Buffer.from('value');
+
+    // Create a tree with a reasonable depth
+    data.forEach(s => {
+      if (s.length !== 64) {
+        s = s.padStart(64, '0');
+      }
+      tree.put(Buffer.from(s, 'hex'), value);
+    });
+
+    tree.pruneStateCache();
+
+    // This should return an error
+    should.throw(() => tree.getFromCache(errorAccount, new Map()));
+  });
+});
+
 describe('Test getFromCache and rlpToMerkleNode', async () => {
   const cache =
       new CachedMerklePatriciaTree<Buffer, Buffer>({putCanDelete: false}, 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1530,13 +1530,15 @@ export function verifyStaleWitness(
   throw new VerificationError('stale witness verification failed');
 }
 
+/** Thrown if we can't find a path for the key (it was probably pruned). */
 export class MerklePrunedError extends Error {
   constructor() {
     super('Failed: path pruned in tree and no matching nodes in node map');
   }
 }
 
-export class KeyNotFoundError extends Error {
+/** Thrown if key in not present in the tree */
+export class MerkleKeyNotFoundError extends Error {
   constructor() {
     super('Failed: Key not found in tree');
   }
@@ -1638,7 +1640,7 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
     } else if (node instanceof ExtensionNode) {
       // Key nibbles should match the nibbles at ExtensionNode
       if (matchingNibbleLength(node.nibbles, key) !== node.nibbles.length) {
-        throw KeyNotFoundError;
+        throw new MerkleKeyNotFoundError();
       }
       // Remove the matchingNibbles from the key
       key.splice(0, node.nibbles.length);
@@ -1649,7 +1651,7 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
     } else if (node instanceof LeafNode) {
       // Key Nibbles should match at the LeafNode
       if (matchingNibbleLength(node.nibbles, key) !== node.nibbles.length) {
-        throw KeyNotFoundError;
+        throw new MerkleKeyNotFoundError();
       }
       // Return the value at LeafNode
       return node.value;
@@ -1660,7 +1662,7 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
       // Get the MerkleNode corresponding to nodeHash from nodeMap
       const mappedNode = nodeMap.get(hash);
       if (!mappedNode) {
-        throw MerklePrunedError;
+        throw new MerklePrunedError();
       }
       // Search down the mappedNode
       const ret = this._getRecursive(key, nodeMap, mappedNode);


### PR DESCRIPTION
This PR adds a new test which checks if we are able to read a value from a cached merkle tree that was pruned. 

In the test, the merkle tree currently returns null. It should throw an error, as there is insufficient information to determine whether or not the key exists or not.

See issue #88