### PR TITLE
putWthNodeBag to insert into CachedMerklePatriciaTree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "4.3.1",
+  "version": "4.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6983,9 +6983,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
-      "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -7409,9 +7409,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
           "dev": true
         },
         "source-map": {
@@ -7784,9 +7784,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.3.4000",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
-      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
+      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
       "dev": true
     },
     "uglify-js": {
@@ -8115,9 +8115,9 @@
       }
     },
     "webpack": {
-      "version": "4.29.6",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.6.tgz",
-      "integrity": "sha512-MwBwpiE1BQpMDkbnUUaW6K8RFZjljJHArC6tWQJoFm0oQtfoSebtg4Y7/QHnJ/SddtjYLHaKGX64CFjG5rehJw==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.30.0.tgz",
+      "integrity": "sha512-4hgvO2YbAFUhyTdlR4FNyt2+YaYBYHavyzjCMbZzgglo02rlKi/pcsEzwCuCpsn1ryzIl1cq/u8ArIKu8JBYMg==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -8147,9 +8147,9 @@
       },
       "dependencies": {
         "tapable": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
-          "integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+          "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "ts-loader": "^4.5.0",
     "ts-node": "^7.0.1",
     "typedoc": "^0.14.2",
-    "typescript": "^3.3.4000",
-    "webpack": "^4.29.6",
+    "typescript": "^3.4.3",
+    "webpack": "^4.30.0",
     "webpack-cli": "^3.3.0"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "An implementation of the modified merkle patricia tree used in Ethereum, optimized for in-memory usage",
   "main": "build/src/index.js",
   "types": "build/src/index.d.js",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -890,10 +890,11 @@ describe('Test getFromCache and rlpToMerkleNode', async () => {
     v3!.should.deep.equal(Buffer.from('xxxx'));
   });
 
+  const nodeMap = new Map();
+  let extensionNodeHash: bigint|undefined;
+
   it('test getFromCache with non-empty nodeMap', async () => {
-    const nodeMap = new Map();
     const bagNodesUsed = new Set<bigint>();
-    let extensionNodeHash: bigint|undefined;
     if (cache.rootNode instanceof BranchNode) {
       for (const branch of (cache.rootNode).branches) {
         if (branch) {
@@ -927,5 +928,39 @@ describe('Test getFromCache and rlpToMerkleNode', async () => {
     v3!.should.deep.equal(Buffer.from('xxxx'));
     bagNodesUsed.size.should.equal(1);
     bagNodesUsed.has(extensionNodeHash!).should.equal(true);
+  });
+
+  it('test putWithNodeBag root hashes', async () => {
+    const initRoot = cache.root;
+    const bag1 = new Set<bigint>(), bag2 = new Set<bigint>(),
+          bag3 = new Set<bigint>();
+
+    cache.putWithNodeBag(
+        Buffer.from('abcd'), Buffer.from('abcd'), bag1, nodeMap);
+    cache.putWithNodeBag(
+        Buffer.from('abcx'), Buffer.from('abcx'), bag2, nodeMap);
+    cache.putWithNodeBag(
+        Buffer.from('xxxx'), Buffer.from('xxxx'), bag3, nodeMap);
+
+    bag1.size.should.equal(1);
+    bag1.has(extensionNodeHash!).should.equal(true);
+  });
+
+  it('test putWithNodeBag insertions', async () => {
+    const updatedValue = Buffer.from('1234');
+    cache.putWithNodeBag(Buffer.from('abcd'), updatedValue, undefined, nodeMap);
+    cache.putWithNodeBag(Buffer.from('abcx'), updatedValue, undefined, nodeMap);
+    cache.putWithNodeBag(Buffer.from('xxxx'), updatedValue, undefined, nodeMap);
+
+    const v1 = cache.get(Buffer.from('abcd')).value;
+    const v2 = cache.get(Buffer.from('abcx')).value;
+    const v3 = cache.get(Buffer.from('xxxx')).value;
+
+    should.exist(v1);
+    should.exist(v2);
+    should.exist(v3);
+    v1!.should.deep.equal(updatedValue);
+    v2!.should.deep.equal(updatedValue);
+    v3!.should.deep.equal(updatedValue);
   });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -795,6 +795,15 @@ describe('test cached merkle tree', async () => {
   });
 });
 
+describe('Test put in pruned CachedMerklePatriciaTree', async () => {
+  const cache = new CachedMerklePatriciaTree({putCanDelete: false}, 1);
+  cache.put(Buffer.from('abcd'), Buffer.from('abcd'));
+  cache.put(Buffer.from('abxx'), Buffer.from('abxx'));
+  cache.put(Buffer.from('xxxx'), Buffer.from('xxxx'));
+  cache.pruneStateCache();
+  should.throw(() => cache.put(Buffer.from('abcd'), Buffer.from('1234')));
+});
+
 describe('Test getFromCache and rlpToMerkleNode', async () => {
   const cache =
       new CachedMerklePatriciaTree<Buffer, Buffer>({putCanDelete: false}, 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1785,11 +1785,13 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
   }
 
   /**
-   * putWithNodeBag inserts k,v pairs and rebuilds the pruned CachedMerklePatriciaTree if needed
+   * putWithNodeBag inserts k,v pairs and rebuilds the pruned
+   * CachedMerklePatriciaTree if needed
    * @param key : key to insert or modify
    * @param value : value corresponding to the key
-   * @param usedNodes : A list of nodes used from the nodeBag for rebuilding the cached tree
-   * The usedNodes hashes change due to the insertion of the k, v pair into the tree
+   * @param usedNodes : A list of nodes used from the nodeBag for rebuilding the
+   * cached tree The usedNodes hashes change due to the insertion of the k, v
+   * pair into the tree
    * @param nodeBag : A Map of nodes indexed by their hashes
    */
   putWithNodeBag(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1909,7 +1909,7 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
           currNode.nextNode = witness.proof[result.stack.length];
         }
       } else {
-        // Tree path for the key has depth < 6; perform insertion
+        // Tree path for the key has depth < pruneDepth; perform insertion
         this.insert(result.stack, result.remainder, witness.value!);
       }
       // Clear all memoized hashes in the path, they will be reset.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1784,6 +1784,14 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
     }
   }
 
+  /**
+   * putWithNodeBag inserts k,v pairs and rebuilds the pruned CachedMerklePatriciaTree if needed
+   * @param key : key to insert or modify
+   * @param value : value corresponding to the key
+   * @param usedNodes : A list of nodes used from the nodeBag for rebuilding the cached tree
+   * The usedNodes hashes change due to the insertion of the k, v pair into the tree
+   * @param nodeBag : A Map of nodes indexed by their hashes
+   */
   putWithNodeBag(
       key: K, value: V, usedNodes: Set<bigint>|undefined,
       ...nodeBag: Array<Map<bigint, MerklePatriciaTreeNode<V>>>) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1785,7 +1785,7 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
   }
 
   putWithNodeBag(
-      key: K, value: V, staleNodes: Set<bigint>|undefined,
+      key: K, value: V, usedNodes: Set<bigint>|undefined,
       ...nodeBag: Array<Map<bigint, MerklePatriciaTreeNode<V>>>) {
     const result = this.search(key);
 
@@ -1815,8 +1815,8 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
             for (const nodeMap of nodeBag) {
               if (nodeMap.has(replaceHash)) {
                 replaceNode = nodeMap.get(replaceHash);
-                if (staleNodes) {
-                  staleNodes.add(replaceHash);
+                if (usedNodes) {
+                  usedNodes.add(replaceHash);
                 }
                 break;
               }
@@ -1843,8 +1843,8 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
             for (const nodeMap of nodeBag) {
               if (nodeMap.has(replaceHash)) {
                 replaceNode = nodeMap.get(replaceHash);
-                if (staleNodes) {
-                  staleNodes.add(replaceHash);
+                if (usedNodes) {
+                  usedNodes.add(replaceHash);
                 }
                 break;
               }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1057,6 +1057,8 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
             throw new Error('Unexpected non-branch node in update');
           }
         }
+      } else {
+        throw new Error('Unexpected node while inserting into tree');
       }
     }
   }


### PR DESCRIPTION
This PR adds a new call to insert key value pairs into the `CachedMerklePatriciaTree`.
```  
putWithNodeBag(
      key: K, value: V, staleNodes: Set<bigint>|undefined,
      ...nodeBag: Array<Map<bigint, MerklePatriciaTreeNode<V>>>)
```
putWithNodeBag takes the key, value pair to insert, a set to populate the nodes in the nodeBag that become stale and a nodeBag which is a cache of MerklePatriciaTreeNodes