### PR TITLE
Update merkle node hash computation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "4.5.0",
+  "version": "4.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "description": "An implementation of the modified merkle patricia tree used in Ethereum, optimized for in-memory usage",
   "main": "build/src/index.js",
   "types": "build/src/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "An implementation of the modified merkle patricia tree used in Ethereum, optimized for in-memory usage",
   "main": "build/src/index.js",
   "types": "build/src/index.d.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1751,7 +1751,7 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
         // ExtensionNode
         if (hash[1] instanceof Buffer && hash[1].length === 32) {
           // Hash is serialized; create HashNode
-          const next = new HashNode<V>(toBigIntBE(hash[1] as Buffer), raw);
+          const next = new HashNode<V>(toBigIntBE(hash[1] as Buffer));
           const ret = new ExtensionNode<V>(decodeHash.nibbles, next);
           return ret;
         } else {
@@ -1778,7 +1778,7 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
         }
         if (branch instanceof Buffer && branch.length === 32) {
           // Hash is serialized; create HashNode
-          ret.branches[bIndex] = new HashNode<V>(toBigIntBE(branch), raw);
+          ret.branches[bIndex] = new HashNode<V>(toBigIntBE(branch));
         } else {
           // Node is serialized; recursively decode the node
           ret.branches[bIndex] =

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,8 +438,7 @@ export class BranchNode<V> extends MerklePatriciaTreeNode<V> {
         hashedBranches[idx] = Buffer.from([]);
       } else if (branch instanceof HashNode) {
         hashedBranches[idx] = toBufferBE(branch.nodeHash, 32);
-      }
-      else if (
+      } else if (
           branch instanceof BranchNode || (branch.nibbles.length / 2) > 30) {
         // Will be >32 when RLP serialized, so just hash
         hashedBranches[idx] =

--- a/src/index.ts
+++ b/src/index.ts
@@ -436,7 +436,10 @@ export class BranchNode<V> extends MerklePatriciaTreeNode<V> {
     for (const [idx, branch] of this.branches.entries()) {
       if (branch === undefined) {
         hashedBranches[idx] = Buffer.from([]);
-      } else if (
+      } else if (branch instanceof HashNode) {
+        hashedBranches[idx] = toBufferBE(branch.nodeHash, 32);
+      }
+      else if (
           branch instanceof BranchNode || (branch.nibbles.length / 2) > 30) {
         // Will be >32 when RLP serialized, so just hash
         hashedBranches[idx] =
@@ -512,7 +515,12 @@ export class ExtensionNode<V> extends MerklePatriciaTreeNode<V> {
 
   /** @inheritdoc */
   serialize(options: MerklePatriciaTreeOptions<{}, V>) {
-    const serialized = this.nextNode!.serialize(options);
+    let serialized: RlpItem;
+    if (this.nextNode instanceof HashNode) {
+      serialized = toBufferBE(this.nextNode.nodeHash, 32);
+    } else {
+      serialized = this.nextNode!.serialize(options);
+    }
     const rlpEncodeNextNode = this.nextNode!.getRlpNodeEncoding(options);
     return [
       MerklePatriciaTreeNode.toBuffer(this.nibbles, this.prefix),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1744,7 +1744,7 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
         // ExtensionNode
         if (hash[1] instanceof Buffer && hash[1].length === 32) {
           // Hash is serialized; create HashNode
-          const next = new HashNode<V>(toBigIntBE(hash[1] as Buffer));
+          const next = new HashNode<V>(toBigIntBE(hash[1] as Buffer), raw);
           const ret = new ExtensionNode<V>(decodeHash.nibbles, next);
           return ret;
         } else {
@@ -1771,7 +1771,7 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
         }
         if (branch instanceof Buffer && branch.length === 32) {
           // Hash is serialized; create HashNode
-          ret.branches[bIndex] = new HashNode<V>(toBigIntBE(branch));
+          ret.branches[bIndex] = new HashNode<V>(toBigIntBE(branch), raw);
         } else {
           // Node is serialized; recursively decode the node
           ret.branches[bIndex] =


### PR DESCRIPTION
This PR updates the MerklePatriciaTreeNode hash function to accommodate for HashNodes