### PR TITLE
Node count and tree size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "description": "An implementation of the modified merkle patricia tree used in Ethereum, optimized for in-memory usage",
   "main": "build/src/index.js",
   "types": "build/src/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "An implementation of the modified merkle patricia tree used in Ethereum, optimized for in-memory usage",
   "main": "build/src/index.js",
   "types": "build/src/index.d.js",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -964,3 +964,37 @@ describe('Test getFromCache and rlpToMerkleNode', async () => {
     v3!.should.deep.equal(updatedValue);
   });
 });
+
+describe('Test nodeCount', async () => {
+  const tree = new CachedMerklePatriciaTree({putCanDelete: false}, 1);
+  const value = Buffer.from('1234');
+
+  it('Test nodeCount with empty tree', async () => {
+    const nodeCount = tree.nodeCount();
+    nodeCount.should.equal(1);
+  });
+
+  it('Test nodeCount with a LeafNode', async () => {
+    tree.put(Buffer.from('abcd'), value);
+    const nodeCount = tree.nodeCount();
+    nodeCount.should.equal(1);
+  });
+
+  it('Test nodeCount with BranchNode', async () => {
+    tree.put(Buffer.from('xxxx'), value);
+    const nodeCount = tree.nodeCount();
+    nodeCount.should.equal(3);
+  });
+
+  it('Test nodeCount with Extension, Branch and Leaf', async () => {
+    tree.put(Buffer.from('abef'), value);
+    const nodeCount = tree.nodeCount();
+    nodeCount.should.equal(6);
+  });
+
+  it('Test nodeCount with HashNodes', async () => {
+    tree.pruneStateCache();
+    const nodeCount = tree.nodeCount();
+    nodeCount.should.equal(3);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ export abstract class MerklePatriciaTreeNode<V> {
   markForCopy = false;
 
   /**
-   * Serializes and computed the RLP encoding of the node
+   * Serializes and computes the RLP encoding of the node
    * Also stores it for future references.
    */
   getRlpNodeEncoding(options: MerklePatriciaTreeOptions<{}, V>): Buffer {
@@ -128,6 +128,25 @@ export abstract class MerklePatriciaTreeNode<V> {
    */
   clearRlpNodeEncoding() {
     this.rlpNodeEncoding = null;
+  }
+
+  /**
+   * Serializes and computes the RLP encoding of the node and returns
+   * the length of the rlp encoding of the node.
+   * getNodeRlpSize also stores the computed rlp encoding for future references.
+   */
+  getNodeRlpSize(options: MerklePatriciaTreeOptions<{}, V>): number {
+    if (this.rlpNodeEncoding) {
+      return this.rlpNodeEncoding.length;
+    }
+    if (options.memoizeSerialization === undefined ||
+        options.memoizeSerialization === false) {
+      return RlpEncode(this.serialize(options)).length;
+    }
+    if (this.rlpNodeEncoding === null) {
+      this.rlpNodeEncoding = RlpEncode(this.serialize(options));
+    }
+    return this.rlpNodeEncoding.length;
   }
 
 
@@ -1313,6 +1332,63 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
       }
     }
     return {value, proof};
+  }
+
+  /**
+   * Counts the number of nodes in the tree
+   */
+  nodeCount(count = 0): number {
+    return this._getNodeCount(this.rootNode);
+  }
+
+  /**
+   * Returns the sum of lengths of rlpEncodings of all the nodes in the tree
+   */
+  size(): number {
+    return this._getSize(this.rootNode);
+  }
+
+  // TODO: Maybe return the number of nodes of each type...
+  private _getNodeCount(node: MerklePatriciaTreeNode<V>): number {
+    if (node instanceof NullNode) {
+      return 1;
+    } else if (node instanceof BranchNode) {
+      let count = 0;
+      for (const branch of node.branches) {
+        if (branch) {
+          count += this._getNodeCount(branch);
+        }
+      }
+      return 1 + count;
+    } else if (node instanceof ExtensionNode) {
+      const count = this._getNodeCount(node.nextNode);
+      return 1 + count;
+    } else if (node instanceof HashNode || node instanceof LeafNode) {
+      return 1;
+    }
+    throw new Error('Unknown node type');
+  }
+
+  private _getSize(node: MerklePatriciaTreeNode<V>): number {
+    const nodeSize =
+        node.getNodeRlpSize(this.options as MerklePatriciaTreeOptions<{}, V>);
+    if (node instanceof NullNode) {
+      return nodeSize;
+    } else if (node instanceof BranchNode) {
+      let size = 0;
+      for (const branch of node.branches) {
+        if (branch) {
+          size += this._getSize(branch);
+        }
+      }
+      return nodeSize + size;
+    } else if (node instanceof ExtensionNode) {
+      const size = this._getSize(node.nextNode);
+      return nodeSize + size;
+    } else if (node instanceof HashNode || node instanceof LeafNode) {
+      return nodeSize;
+    }
+    throw new Error('Unknown node type');
   }
 }
 


### PR DESCRIPTION
This PR adds two new API calls to MerklePatriciaTree and CachedMerklePatriciaTree:
nodeCount and size.

nodeCount recursively traverses the tree and counts the number of nodes present in the it.
size returns the length of the concatenation of rlp encodings of all the nodes in the tree.