### PR TITLE
Batch cow with node bag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "description": "An implementation of the modified merkle patricia tree used in Ethereum, optimized for in-memory usage",
   "main": "build/src/index.js",
   "types": "build/src/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "4.10.0",
+  "version": "5.0.0",
   "description": "An implementation of the modified merkle patricia tree used in Ethereum, optimized for in-memory usage",
   "main": "build/src/index.js",
   "types": "build/src/index.d.js",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,7 +4,7 @@ import * as chai from 'chai';
 import * as path from 'path';
 import {RlpEncode, RlpList} from 'rlp-stream';
 
-import {BranchNode, CachedMerklePatriciaTree, ExtensionNode, HashNode, LeafNode, MerklePatriciaTree, MerklePatriciaTreeOptions, NullNode, verifyWitness} from './index';
+import {BatchPut, BranchNode, CachedMerklePatriciaTree, ExtensionNode, HashNode, LeafNode, MerklePatriciaTree, MerklePatriciaTreeNode, MerklePatriciaTreeOptions, NullNode, verifyWitness} from './index';
 
 const utils = require('ethereumjs-util');
 
@@ -947,10 +947,11 @@ describe('Test getFromCache and rlpToMerkleNode', async () => {
   });
 
   it('test putWithNodeBag insertions', async () => {
+    const nodesUsed = new Set<bigint>();
     const updatedValue = Buffer.from('1234');
-    cache.putWithNodeBag(Buffer.from('abcd'), updatedValue, undefined, nodeMap);
-    cache.putWithNodeBag(Buffer.from('abcx'), updatedValue, undefined, nodeMap);
-    cache.putWithNodeBag(Buffer.from('xxxx'), updatedValue, undefined, nodeMap);
+    cache.putWithNodeBag(Buffer.from('abcd'), updatedValue, nodesUsed, nodeMap);
+    cache.putWithNodeBag(Buffer.from('abcx'), updatedValue, nodesUsed, nodeMap);
+    cache.putWithNodeBag(Buffer.from('xxxx'), updatedValue, nodesUsed, nodeMap);
 
     const v1 = cache.get(Buffer.from('abcd')).value;
     const v2 = cache.get(Buffer.from('abcx')).value;
@@ -996,5 +997,65 @@ describe('Test nodeCount', async () => {
     tree.pruneStateCache();
     const nodeCount = tree.nodeCount();
     nodeCount.should.equal(3);
+  });
+});
+
+describe('Test batchCOW with nodeBag on CachedMerkleTree', async () => {
+  const cache = new CachedMerklePatriciaTree<Buffer, Buffer>();
+  const value = Buffer.from('1234');
+  const updatedValue = Buffer.from('1234');
+  const nodesUsed = new Set<bigint>();
+  const nodeMap = new Map<bigint, MerklePatriciaTreeNode<Buffer>>();
+
+  it('Test batchCOW copy on write functionality', async () => {
+    cache.put(Buffer.from('abcd'), value);
+    cache.put(Buffer.from('abcx'), value);
+    cache.put(Buffer.from('xxxx'), value);
+    const root = cache.root;
+
+    let extensionNodeHash: bigint;
+    if (cache.rootNode instanceof BranchNode) {
+      for (const branch of (cache.rootNode).branches) {
+        if (branch) {
+          const node = branch.getRlpNodeEncoding(
+              cache.options as {} as MerklePatriciaTreeOptions<{}, Buffer>);
+          const hash = branch.hash(
+              cache.options as {} as MerklePatriciaTreeOptions<{}, Buffer>);
+          const mappedNode = cache.rlpToMerkleNode(node, (val: Buffer) => val);
+          nodeMap.set(hash, mappedNode);
+          if (mappedNode instanceof ExtensionNode) {
+            extensionNodeHash = hash;
+          }
+        }
+      }
+      const branch6 = cache.rootNode.branches[6];
+      if (branch6 instanceof ExtensionNode) {
+        const node2 = branch6.nextNode.getRlpNodeEncoding(
+            cache.options as {} as MerklePatriciaTreeOptions<{}, Buffer>);
+        const hash2 = branch6.nextNode.hash(
+            cache.options as {} as MerklePatriciaTreeOptions<{}, Buffer>);
+        const mapNode2 = cache.rlpToMerkleNode(node2, (val: Buffer) => val);
+        nodeMap.set(hash2, mapNode2);
+      }
+    }
+    cache.pruneStateCache();
+
+    const putOps = new Array<BatchPut<Buffer, Buffer>>();
+    putOps.push({key: Buffer.from('abcd'), val: updatedValue});
+    putOps.push({key: Buffer.from('abcx'), val: updatedValue});
+    putOps.push({key: Buffer.from('xxxx'), val: updatedValue});
+
+    const newCache = cache.batchCOWwithNodeBag(putOps, nodesUsed, nodeMap);
+
+    const oldRoot = cache.root;
+    oldRoot.should.deep.equal(root);
+
+    const v1 = newCache.getFromCache(Buffer.from('abcd'), undefined, nodeMap);
+    const v2 = newCache.getFromCache(Buffer.from('abcd'), undefined, nodeMap);
+    const v3 = newCache.getFromCache(Buffer.from('abcd'), undefined, nodeMap);
+
+    v1.should.deep.equal(updatedValue);
+    v2.should.deep.equal(updatedValue);
+    v3.should.deep.equal(updatedValue);
   });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1001,7 +1001,7 @@ describe('Test nodeCount', async () => {
 });
 
 describe('Test batchCOW with nodeBag on CachedMerkleTree', async () => {
-  const cache = new CachedMerklePatriciaTree<Buffer, Buffer>();
+  const cache = new CachedMerklePatriciaTree<Buffer, Buffer>({putCanDelete: false}, 1);
   const value = Buffer.from('1234');
   const updatedValue = Buffer.from('1234');
   const nodesUsed = new Set<bigint>();
@@ -1058,4 +1058,8 @@ describe('Test batchCOW with nodeBag on CachedMerkleTree', async () => {
     v2.should.deep.equal(updatedValue);
     v3.should.deep.equal(updatedValue);
   });
+
+  it('batchCOWwithNodeBag should set nodes used', async () => {
+    nodesUsed.size.should.not.equal(0);
+  })
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1001,7 +1001,8 @@ describe('Test nodeCount', async () => {
 });
 
 describe('Test batchCOW with nodeBag on CachedMerkleTree', async () => {
-  const cache = new CachedMerklePatriciaTree<Buffer, Buffer>({putCanDelete: false}, 1);
+  const cache =
+      new CachedMerklePatriciaTree<Buffer, Buffer>({putCanDelete: false}, 1);
   const value = Buffer.from('1234');
   const updatedValue = Buffer.from('1234');
   const nodesUsed = new Set<bigint>();
@@ -1061,5 +1062,5 @@ describe('Test batchCOW with nodeBag on CachedMerkleTree', async () => {
 
   it('batchCOWwithNodeBag should set nodes used', async () => {
     nodesUsed.size.should.not.equal(0);
-  })
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -826,34 +826,19 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
     } else if (node instanceof LeafNode) {
       const copyNode = new LeafNode<V>(node.nibbles, node.value);
       return copyNode;
+    } else if (node instanceof HashNode) {
+      const nodeSerialization = (node.serialization)? node.serialization: undefined;
+      const copyNode = new HashNode<V>(node.nodeHash, nodeSerialization);
+      return copyNode;
     }
     return new NullNode<V>();
-  }
-
-  private copyPath(key: K, newTree: MerklePatriciaTree<K, V>, flag?: boolean) {
-    let keyNibbles: number[] =
-        MerklePatriciaTreeNode.bufferToNibbles(this.options.keyConverter!(key));
-    let currNode: MerklePatriciaTreeNode<V>|null = newTree.rootNode;
-    let nextNode: MerklePatriciaTreeNode<V>|null;
-    const result: SearchResult<V> = this.search(key);
-    for (let i = 1; i < result.stack.length; i++) {
-      nextNode = this.getNodeCopy(result.stack[i]);
-      if (currNode instanceof BranchNode) {
-        currNode.branches[keyNibbles[0]] = nextNode;
-        keyNibbles.shift();
-      } else if (currNode instanceof ExtensionNode) {
-        currNode.nextNode = nextNode;
-        keyNibbles = keyNibbles.slice(currNode.nibbles.length);
-      }
-      currNode = nextNode;
-    }
   }
 
   /**
    * CopyTreePaths
    * Copies paths that are marked for copy
    */
-  private copyTreePaths(
+  copyTreePaths(
       node1: MerklePatriciaTreeNode<V>,
       node2: MerklePatriciaTreeNode<V>): MerklePatriciaTreeNode<V> {
     if (node1.markForCopy) {
@@ -870,6 +855,7 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
           node1 instanceof ExtensionNode && node2 instanceof ExtensionNode) {
         node2.nextNode = this.copyTreePaths(node1.nextNode, node2.nextNode);
       } else if (
+          node1 instanceof HashNode && node2 instanceof HashNode ||
           node1 instanceof LeafNode && node2 instanceof LeafNode ||
           node1 instanceof NullNode && node2 instanceof NullNode) {
         return node2;
@@ -1894,6 +1880,34 @@ export class CachedMerklePatriciaTree<K, V> extends MerklePatriciaTree<K, V> {
     for (const node of updatedResult.stack) {
       node.clearMemoizedHash();
     }
+  }
+
+  batchCOWwithNodeBag(
+      putOps: Array<BatchPut<K, V>>, delOps: K[],
+      nodesUsed: Set<bigint>|undefined,
+      ...nodeBag: Array<Map<bigint, MerklePatriciaTreeNode<V>>>):
+      CachedMerklePatriciaTree<K, V> {
+    if (putOps.length === 0 && delOps.length === 0) {
+      // If no updates for batchCOW; just return the same tree
+      return this;
+    }
+    // Search the tree and mark the nodes for copy
+    this.multiSearch(putOps, delOps, true);
+    const newTree = new CachedMerklePatriciaTree<K, V>(this.options);
+    // Copy all the nodes marked for copy into the newTree
+    newTree.rootNode = super.copyTreePaths(this.rootNode, newTree.rootNode);
+    // Modify the new Tree: Insert the putOps
+    for (const put of putOps) {
+      newTree.putWithNodeBag(put.key, put.val, nodesUsed, ...nodeBag);
+    }
+    // Modify the new Tree: Delete the delOps
+    for (const key of delOps) {
+      newTree.del(key);
+    }
+    // Reset the nodes marked for copy in the original tree
+    this.multiSearch(putOps, delOps, false);
+    // Return the new tree;
+    return newTree;
   }
 
   verifyAndAddWitness(root: Buffer, key: K, witness: Witness<V>) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -827,7 +827,8 @@ export class MerklePatriciaTree<K = Buffer, V = Buffer> implements
       const copyNode = new LeafNode<V>(node.nibbles, node.value);
       return copyNode;
     } else if (node instanceof HashNode) {
-      const nodeSerialization = (node.serialization)? node.serialization: undefined;
+      const nodeSerialization =
+          (node.serialization) ? node.serialization : undefined;
       const copyNode = new HashNode<V>(node.nodeHash, nodeSerialization);
       return copyNode;
     }


### PR DESCRIPTION
This PR adds `batchCOWwithNodeBag`, a copy-on-write batch put API to `CachedMerklePatriciaTree` which uses nodeBags and returns the nodesUsed and the modified `CachedMerklePatriciaTree`.

Firstly `batchCOWwithNodeBag` marks the nodes that will be modified in the original for copy. The nodes that are marked for copy are copied into a new `CachedMerklePatriciaTree<K, V>`. The updates are performed on the new tree leaving the original tree unmodified.

This PR updates the major version as it adds a new API to `CachedMerklePatriciaTree`.

Fixes #97

API:
```ts
batchCOWwithNodeBag(
      putOps: Array<BatchPut<K, V>>,
      nodesUsed: Set<bigint>|undefined,
      ...nodeBag: Array<Map<bigint, MerklePatriciaTreeNode<V>>>) : 
CachedMerklePatriciaTree<K, V>
```