### PR TITLE
No rlp hash node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/merkle-patricia-tree",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "description": "An implementation of the modified merkle patricia tree used in Ethereum, optimized for in-memory usage",
   "main": "build/src/index.js",
   "types": "build/src/index.d.js",


### PR DESCRIPTION
We actually don't require hashNodes to store rlp while pruning the cache.
This PR changes the computation of the root hash to avoid calling serialize() on HashNodes.